### PR TITLE
#7 pass ECs task exec. policy as input variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ If all provided subnets are public (no NAT gateway) then `ecs_service_assign_pub
 | github_repo_names | Github repositories where webhook should be created | list | `<list>` | no |
 | github_token | Github token | string | `` | no |
 | name | Name to use on all resources created (VPC, ALB, etc) | string | `atlantis` | no |
+| policy_arn | The ARN of the policy you want to apply | string | `arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy` | no |
 | private_subnet_ids | A list of IDs of existing private subnets inside the VPC | list | `<list>` | no |
 | private_subnets | A list of private subnets inside the VPC | list | `<list>` | no |
 | public_subnet_ids | A list of IDs of existing public subnets inside the VPC | list | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -215,7 +215,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
   role       = "${aws_iam_role.ecs_task_execution.id}"
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+  policy_arn = "${var.policy_arn}"
 }
 
 resource "aws_ecs_task_definition" "atlantis" {

--- a/variables.tf
+++ b/variables.tf
@@ -119,6 +119,12 @@ variable "github_repo_names" {
 
 variable "allow_repo_config" {
   description = "When true allows the use of atlantis.yaml config files within the source repos."
-  type = "string"
-  default = "false"
+  type        = "string"
+  default     = "false"
+}
+
+variable "policy_arn" {
+  description = "The ARN of the policy you want to apply"
+  type        = "string"
+  default     = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }


### PR DESCRIPTION
This PR solves #7 by introducing a policies_arn input variable (list, defaults to ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]).