### PR TITLE
Add variable to configure gitlab hostname

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -301,6 +301,10 @@ module "container_definition" {
       value = "${var.allow_repo_config}"
     },
     {
+      name  = "ATLANTIS_GITLAB_HOSTNAME"
+      value = "${var.atlantis_gitlab_hostname}"
+    },
+    {
       name  = "ATLANTIS_LOG_LEVEL"
       value = "debug"
     },

--- a/variables.tf
+++ b/variables.tf
@@ -201,3 +201,8 @@ variable "atlantis_gitlab_user_token" {
   description = "Gitlab token of the user that is running the Atlantis command"
   default     = ""
 }
+
+variable "atlantis_gitlab_hostname" {
+  description = "Gitlab server hostname, defaults to gitlab.com"
+  default     = "gitlab.com"
+}


### PR DESCRIPTION
Allow the gitlab hostname to be configured using the `ATLANTIS_GITLAB_HOSTNAME` environment variable.