### PR TITLE
add vpc_id to outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,11 @@ output "task_role_arn" {
   value       = "${aws_iam_role.ecs_task_execution.arn}"
 }
 
+output "vpc_id" {
+  description = "ID of the VPC that was created or passed in"
+  value       = "${local.vpc_id}"
+}
+
 output "webhook_secret" {
   description = "Webhook secret"
   value       = "${random_id.webhook.hex}"


### PR DESCRIPTION
I would like to add VPC ID to the outputs of the Atlantis terraform module.
Currently, when you spin up a VPC, AWS by default attaches a security group that has permissions that are broader than desirable. In order to remove this security group and replace it with one more appropriate, we'd like to have the VPC ID available to apply more changes after its creation.