### PR TITLE
Output alb dns name

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,8 @@ output "webhook_secret" {
   description = "Webhook secret"
   value       = "${random_id.webhook.hex}"
 }
+
+output "alb_dns_name" {
+  description = "Dns name of alb"
+  value       = "${module.alb.dns_name}"
+}


### PR DESCRIPTION
For our use case, we are using the ALB DNS name to create an external DNS record to the atlantis load balancer. This adds the ALB DNS name to the outputs.