### PR TITLE
Fix github user token env to ATLANTIS_GH_TOKEN

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ locals {
   # Include only one group of secrets - for github, gitlab or bitbucket
   has_secrets = "${var.atlantis_gitlab_user_token != "" || var.atlantis_github_user_token != "" || var.atlantis_bitbucket_user_token != ""}"
 
-  secret_name_key = "${local.has_secrets ? (var.atlantis_gitlab_user_token != "" ? "ATLANTIS_GITLAB_TOKEN" : (var.atlantis_github_user_token != "" ? "ATLANTIS_GITHUB_TOKEN" : "ATLANTIS_BITBUCKET_TOKEN")) : "unknown_secret_name_key"}"
+  secret_name_key = "${local.has_secrets ? (var.atlantis_gitlab_user_token != "" ? "ATLANTIS_GITLAB_TOKEN" : (var.atlantis_github_user_token != "" ? "ATLANTIS_GH_TOKEN" : "ATLANTIS_BITBUCKET_TOKEN")) : "unknown_secret_name_key"}"
 
   secret_name_value_from = "${local.has_secrets ? (var.atlantis_gitlab_user_token != "" ? var.atlantis_gitlab_user_token_ssm_parameter_name : (var.atlantis_github_user_token != "" ? var.atlantis_github_user_token_ssm_parameter_name : var.atlantis_bitbucket_user_token_ssm_parameter_name)) : "unknown_secret_name_value"}"
 


### PR DESCRIPTION
Fixed to follow atlantis master using `ATLANTIS_GH_TOKEN` not `ATLANTIS_GITHUB_TOKEN`

https://github.com/runatlantis/atlantis/blob/master/cmd/server.go#L137