### PR TITLE
Add optional support for ALB logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ If all provided subnets are public (no NAT gateway) then `ecs_service_assign_pub
 |------|-------------|:----:|:-----:|:-----:|
 | acm\_certificate\_domain\_name | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance. Specify if it is different from value in `route53_zone_name` | string | `""` | no |
 | alb\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules of the ALB. | list | `[ "0.0.0.0/0" ]` | no |
+| alb\_log\_bucket\_name | S3 bucket (externally created) for storing load balancer access logs. Required if alb_logging_enabled is true. | string | `""` | no |
+| alb\_log\_location\_prefix | S3 prefix within the log_bucket_name under which logs are stored. | string | `""` | no |
+| alb\_logging\_enabled | Controls if the ALB will log requests to S3. | string | `"false"` | no |
 | allow\_repo\_config | When true allows the use of atlantis.yaml config files within the source repos. | string | `"false"` | no |
 | atlantis\_allowed\_repo\_names | Github repositories where webhook should be created | list | `[]` | no |
 | atlantis\_bitbucket\_user | Bitbucket username that is running the Atlantis command | string | `""` | no |

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ If all provided subnets are public (no NAT gateway) then `ecs_service_assign_pub
 
 | Name | Description |
 |------|-------------|
+| alb\_dns\_name | Dns name of alb |
 | atlantis\_allowed\_repo\_names | Github repositories where webhook should be created |
 | atlantis\_url | URL of Atlantis |
 | atlantis\_url\_events | Webhook events URL of Atlantis |

--- a/main.tf
+++ b/main.tf
@@ -163,7 +163,10 @@ module "alb" {
   vpc_id          = "${local.vpc_id}"
   subnets         = ["${local.public_subnet_ids}"]
   security_groups = ["${module.alb_https_sg.this_security_group_id}", "${module.alb_http_sg.this_security_group_id}"]
-  logging_enabled = false
+
+  logging_enabled     = "${var.alb_logging_enabled}"
+  log_bucket_name     = "${var.alb_log_bucket_name}"
+  log_location_prefix = "${var.alb_log_location_prefix}"
 
   https_listeners = [{
     port            = 443

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,24 @@ variable "alb_ingress_cidr_blocks" {
   default     = ["0.0.0.0/0"]
 }
 
+variable "alb_log_bucket_name" {
+  description = "S3 bucket (externally created) for storing load balancer access logs. Required if alb_logging_enabled is true."
+  type        = "string"
+  default     = ""
+}
+
+variable "alb_log_location_prefix" {
+  description = "S3 prefix within the log_bucket_name under which logs are stored."
+  type        = "string"
+  default     = ""
+}
+
+variable "alb_logging_enabled" {
+  description = "Controls if the ALB will log requests to S3."
+  type        = "string"
+  default     = false
+}
+
 # ACM
 variable "certificate_arn" {
   description = "ARN of certificate issued by AWS ACM. If empty, a new ACM certificate will be created and validated using Route53 DNS"


### PR DESCRIPTION
Adds variables so the Atlantis ALB will log to a specified S3 bucket using a specified prefix. By default, logging is disabled to be backwards compatible.