### PR TITLE
Add Task Definition Output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -32,3 +32,8 @@ output "alb_dns_name" {
   description = "Dns name of alb"
   value       = "${module.alb.dns_name}"
 }
+
+output "ecs_task_definition" {
+  description = "Task definition for ECS service (used for external triggers)"
+  value       = "${aws_ecs_service.atlantis.task_definition}"
+}


### PR DESCRIPTION
I want to trigger a `null_resource` to wait for the deployment to complete. Adding a `task_definition` output gives me something to trigger on other than `uuid()`