### PR TITLE
fix task version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -488,20 +488,10 @@ resource "aws_ecs_task_definition" "atlantis" {
   container_definitions = local.container_definitions
 }
 
-data "aws_ecs_task_definition" "atlantis" {
-  task_definition = var.name
-
-  //  Commented out to avoid always-changed status every time during "terraform apply"
-  //  depends_on      = [aws_ecs_task_definition.atlantis]
-}
-
 resource "aws_ecs_service" "atlantis" {
   name    = var.name
   cluster = module.ecs.this_ecs_cluster_id
-  task_definition = "${data.aws_ecs_task_definition.atlantis.family}:${max(
-    aws_ecs_task_definition.atlantis.revision,
-    data.aws_ecs_task_definition.atlantis.revision,
-  )}"
+  task_definition = "${aws_ecs_task_definition.atlantis.family}:${aws_ecs_task_definition.atlantis.revision}"
   desired_count                      = var.ecs_service_desired_count
   launch_type                        = "FARGATE"
   deployment_maximum_percent         = var.ecs_service_deployment_maximum_percent


### PR DESCRIPTION
# Description

Fixes issues with creating the service caused by commenting out the `depends_on` in `data.aws_ecs_service.atlantis`. This also removes the ability to select the greater of the versions between what's in state and what data returns, but the version in state should be preferable to the version returned as data anyway. If there's a reason for this behavior that I'm not understanding please let me know.

Fixes #59 