### PR TITLE
Add capability to attach additional security groups to ALB

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ If all provided subnets are public (no NAT gateway) then `ecs_service_assign_pub
 | public\_subnet\_ids | A list of IDs of existing public subnets inside the VPC | list | `[]` | no |
 | public\_subnets | A list of public subnets inside the VPC | list | `[]` | no |
 | route53\_zone\_name | Route53 zone name to create ACM certificate in and main A-record, without trailing dot | string | `""` | no |
+| security\_group\_ids | List of one or more security groups to be added to the load balancer. Adding more than 3 will exceed the default limit for security groups attached | list | `[]` | no |
 | ssm\_kms\_key\_arn | ARN of KMS key to use for entryption and decryption of SSM Parameters. Required only if your key uses a custom KMS key and not the default key | string | `""` | no |
 | tags | A map of tags to use on all resources | map | `{}` | no |
 | vpc\_id | ID of an existing VPC where resources will be created | string | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -171,7 +171,7 @@ module "alb" {
 
   vpc_id          = local.vpc_id
   subnets         = local.public_subnet_ids
-  security_groups = [module.alb_https_sg.this_security_group_id, module.alb_http_sg.this_security_group_id]
+  security_groups = flatten([module.alb_https_sg.this_security_group_id, module.alb_http_sg.this_security_group_id, var.security_group_ids])
 
   logging_enabled     = var.alb_logging_enabled
   log_bucket_name     = var.alb_log_bucket_name

--- a/variables.tf
+++ b/variables.tf
@@ -290,3 +290,8 @@ variable "custom_environment_variables" {
   default     = []
 }
 
+variable "security_group_ids" {
+  description = "List of one or more security groups to be added to the load balancer"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
# Description

This change is to allow a list of security group IDs to be added to the load balancer. This will enable externally created security groups to be passed through to the ALB module.
