### PR TITLE
Allow specifying atlantis_url directly

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,7 @@ locals {
   # Atlantis
   atlantis_image = var.atlantis_image == "" ? "runatlantis/atlantis:${var.atlantis_version}" : var.atlantis_image
   atlantis_url = "https://${coalesce(
+    var.atlantis_url,
     element(concat(aws_route53_record.atlantis.*.fqdn, [""]), 0),
     module.alb.dns_name,
     "_"

--- a/variables.tf
+++ b/variables.tf
@@ -278,6 +278,12 @@ variable "atlantis_bitbucket_user_token" {
   default     = ""
 }
 
+variable "atlantis_url" {
+  description = "The URL that Atlantis is accessible at"
+  type        = string
+  default     = ""
+}
+
 variable "custom_environment_secrets" {
   description = "List of additional secrets the container will use (list should contain maps with `name` and `valueFrom`)"
   type        = list(map(string))


### PR DESCRIPTION
# Description

By default, this module will use the DNS name of the load balancer it creates.

This DNS name doesn't match the Route53 record created for atlantis, and thus will give an SSL error if you have created an ACM certificate for the Route53 record/zone.

This change allows one to override the `atlantis_url`.
