### PR TITLE
Allow more secure practices (no secret leaking, internal alb)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -180,7 +180,7 @@ module "alb" {
   log_bucket_name     = var.alb_log_bucket_name
   log_location_prefix = var.alb_log_location_prefix
 
-  load_balancer_is_internal = true
+  load_balancer_is_internal = var.internal_alb
 
   https_listeners = [
     {

--- a/main.tf
+++ b/main.tf
@@ -105,15 +105,16 @@ data "aws_route53_zone" "this" {
 # Secret for webhook
 ###################
 resource "random_id" "webhook" {
+  count       = var.preexisting_webhook_ssm_parameter ? 0 : 1
   byte_length = "64"
 }
 
 resource "aws_ssm_parameter" "webhook" {
-  count = var.atlantis_bitbucket_user_token != "" ? 0 : 1
+  count = var.preexisting_webhook_ssm_parameter ? 0 : 1
 
   name  = var.webhook_ssm_parameter_name
   type  = "SecureString"
-  value = random_id.webhook.hex
+  value = random_id.webhook.0.hex
 }
 
 resource "aws_ssm_parameter" "atlantis_github_user_token" {

--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,10 @@ locals {
       value = var.atlantis_bitbucket_user
     },
     {
+      name  = "ATLANTIS_BITBUCKET_BASE_URL",
+      value = var.atlantis_bitbucket_base_url
+    },
+    {
       name  = "ATLANTIS_REPO_WHITELIST"
       value = join(",", var.atlantis_repo_whitelist)
     },

--- a/main.tf
+++ b/main.tf
@@ -179,6 +179,8 @@ module "alb" {
   log_bucket_name     = var.alb_log_bucket_name
   log_location_prefix = var.alb_log_location_prefix
 
+  load_balancer_is_internal = true
+
   https_listeners = [
     {
       port            = 443

--- a/variables.tf
+++ b/variables.tf
@@ -112,6 +112,17 @@ variable "cloudwatch_log_retention_in_days" {
 }
 
 # SSM parameters for secrets
+variable "git_provider" {
+  description = "One of github/gitlab/bitbucket. Used to determine which git provider Atlantis will connect with and which ssm parameter to use."
+  type        = string
+}
+
+variable "preexisting_user_token_ssm_parameter" {
+  description = "This should be true if you already stored the user token in the SSM Parameter. NOTE: This must either be true or you must pass the token into the corresponding input variable for your git provider."
+  type        = bool
+  default     = false
+}
+
 variable "webhook_ssm_parameter_name" {
   description = "Name of SSM parameter to keep webhook secret"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -123,6 +123,12 @@ variable "preexisting_user_token_ssm_parameter" {
   default     = false
 }
 
+variable "preexisting_webhook_ssm_parameter" {
+  description = "This should be true if you already stored the webhook secret in the SSM Parameter. If false, one will be randomly generated"
+  type        = bool
+  default     = false
+}
+
 variable "webhook_ssm_parameter_name" {
   description = "Name of SSM parameter to keep webhook secret"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,12 @@ variable "private_subnet_ids" {
   default     = []
 }
 
+variable "internal_alb" {
+  description = "Whether or not the ALB will be marked as 'internal' (ie. not exposed to the public internet). Should be true if your 'public_subnet_ids' are actually private."
+  type        = bool
+  default     = false
+}
+
 variable "cidr" {
   description = "The CIDR block for the VPC which will be created if `vpc_id` is not specified"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -289,6 +289,12 @@ variable "atlantis_bitbucket_user_token" {
   default     = ""
 }
 
+variable "atlantis_bitbucket_base_url" {
+  description = "Base URL of Bitbucket Server (aka Stash) installation. Must include http:// or https://. If using Bitbucket Cloud (bitbucket.org), do not set. Defaults to https://api.bitbucket.org."
+  type        = string
+  default     = "https://api.bitbucket.org"
+}
+
 variable "custom_environment_secrets" {
   description = "List of additional secrets the container will use (list should contain maps with `name` and `valueFrom`)"
   type        = list(map(string))


### PR DESCRIPTION
# Description

This patch does the following:

* Allows you to use pre-existing values from SSM instead of having to pass them in through the module (and thus storing your secrets in the state file!) (I believe this addresses https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/67)
* Allow ALB to be internal (https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/69)
* Adds support for the bitbucket_base_url argument (this allows users of Bitbucket Server to use this module as well).
* Adds a "git_provider" argument, which cleans up the logic on choosing which SSM Key/Value to use. As far as I could tell the "has_secrets" variable didn't really make sense, as Atlantis must always be used with one of the three providers and therefore must pull one of the three user tokens. There is no use case where it should be false.

Please let me know if anything needs to be changed and I'll try to respond in a timely manner. Would love to get this merged into mainline as I am currently dependent on these additional features.