### PR TITLE
Security improvements for Atlantis installation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -136,7 +136,7 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "v1.53.0"
 
-  create_vpc = "${var.vpc_id == ""}"
+  create_vpc = false
 
   name = "${var.name}"
 

--- a/modules/github-repository-webhook/main.tf
+++ b/modules/github-repository-webhook/main.tf
@@ -9,7 +9,7 @@ resource "github_repository_webhook" "this" {
   repository = "${var.atlantis_allowed_repo_names[count.index]}"
 
   configuration {
-    url          = "${var.webhook_url}"
+    url          = "${var.webhook_url}?secret=${sha1(var.webhook_secret)}"
     content_type = "application/json"
     insecure_ssl = false
     secret       = "${var.webhook_secret}"

--- a/modules/github-repository-webhook/main.tf
+++ b/modules/github-repository-webhook/main.tf
@@ -6,7 +6,6 @@ provider "github" {
 resource "github_repository_webhook" "this" {
   count = "${var.create_github_repository_webhook && length(var.atlantis_allowed_repo_names) > 0 ? length(var.atlantis_allowed_repo_names) : 0}"
 
-  name       = "web"
   repository = "${var.atlantis_allowed_repo_names[count.index]}"
 
   configuration {

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,10 @@ variable "name" {
   default     = "atlantis"
 }
 
+variable "aws_profile" {
+  description = "Optional, the AWS profile to use with local-exec AWS CLI commands"
+}
+
 variable "tags" {
   description = "A map of tags to use on all resources"
   default     = {}
@@ -88,6 +92,11 @@ variable "acm_certificate_domain_name" {
 # Route53
 variable "route53_zone_name" {
   description = "Route53 zone name to create ACM certificate in and main A-record, without trailing dot"
+  default     = ""
+}
+
+variable "route53_internal_zone_name" {
+  description = "Route53 internal zone name to create ACM certificate in and main A-record, without trailing dot"
   default     = ""
 }
 


### PR DESCRIPTION
# Description
Main issue describing changes: https://github.com/Leadfeeder/issue-tracker/issues/10799

Changes to be done in this module:

- [ ] Internal domain name for atlantis; it shall point to the designated ALB;
- [ ] Internal load balancer/TG naturally accessible only via VPN
- [ ] Public-facing load balancer advanced route conditions:
* POST'S to`https://URI/events` with `?secret=123456` query args go to backend
* GET's get forwarded to internal domain name (...internal ALB -> TG -> backend)
* All other requests not matching above conditions blackholed with `HTTP 503`
- [ ] GitHub webhook module shall be patched to have a query argument with the secret.
- [ ] Atlantis `aws_ecs_service` to update 2 target groups in case of service failure (hot AWS feature 🌶 )