### PR TITLE
feat: add support for bitbucket stash base url

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,10 @@ locals {
       value = var.atlantis_bitbucket_user
     },
     {
+      name  = "ATLANTIS_BITBUCKET_BASE_URL"
+      value = var.atlantis_bitbucket_base_url
+    },
+    {
       name  = "ATLANTIS_REPO_WHITELIST"
       value = join(",", var.atlantis_repo_whitelist)
     },

--- a/terraform.tfvars.sample
+++ b/terraform.tfvars.sample
@@ -39,6 +39,9 @@ atlantis_gitlab_user_token = ""
 atlantis_bitbucket_user = ""
 atlantis_bitbucket_user_token = ""
 
+# For Bitbucket on prem (Stash)
+# atlantis_bitbucket_base_url = ""
+
 # Tags
 tags = {
   Name = "atlantis"

--- a/variables.tf
+++ b/variables.tf
@@ -278,6 +278,12 @@ variable "atlantis_bitbucket_user_token" {
   default     = ""
 }
 
+variable "atlantis_bitbucket_base_url" {
+  description = "Base URL of Bitbucket Server, use for Bitbucket on prem (Stash)"
+  type        = string
+  default     = ""
+}
+
 variable "custom_environment_secrets" {
   description = "List of additional secrets the container will use (list should contain maps with `name` and `valueFrom`)"
   type        = list(map(string))


### PR DESCRIPTION
# Add Support for Bitbucket on prem (Stash) deployments

Add support for Bitbucket on prem by adding the ATLANTIS_BITBUCKET_BASE_URL environment variable to the container environment