### PR TITLE
Upgrade terraform-aws-acm module to v2.4.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -288,7 +288,7 @@ module "atlantis_sg" {
 ###################
 module "acm" {
   source  = "terraform-aws-modules/acm/aws"
-  version = "v2.0.0"
+  version = "v2.4.0"
 
   create_certificate = var.certificate_arn == ""
 
@@ -528,4 +528,3 @@ resource "aws_cloudwatch_log_group" "atlantis" {
 
   tags = local.tags
 }
-


### PR DESCRIPTION
# Description

A bugfix was introduced in this version of the terraform-aws-acm module by https://github.com/terraform-aws-modules/terraform-aws-acm/pull/28.  It addresses an issue that when an external certificate is used, terraform would fail for the module.  We discovered this bug when upgrading our Atlantis infrastructure to use terraform 0.12.
