### PR TITLE
fix: Update "cloudposse/ecs-container-definition/aws" source version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -423,12 +423,13 @@ module "container_definition_github_gitlab" {
   ]
 
   log_configuration = {
-    log_driver = "awslogs"
+    logDriver = "awslogs"
     options = {
       awslogs-region        = data.aws_region.current.name
       awslogs-group         = aws_cloudwatch_log_group.atlantis.name
       awslogs-stream-prefix = "ecs"
     }
+    secretOptions = []
   }
 
   environment = concat(
@@ -463,12 +464,13 @@ module "container_definition_bitbucket" {
   ]
 
   log_configuration = {
-    log_driver = "awslogs"
+    logDriver = "awslogs"
     options = {
       awslogs-region        = data.aws_region.current.name
       awslogs-group         = aws_cloudwatch_log_group.atlantis.name
       awslogs-stream-prefix = "ecs"
     }
+    secretOptions = []
   }
 
   environment = concat(

--- a/main.tf
+++ b/main.tf
@@ -423,9 +423,12 @@ module "container_definition_github_gitlab" {
   ]
 
   log_configuration = {
-    awslogs-region        = data.aws_region.current.name
-    awslogs-group         = aws_cloudwatch_log_group.atlantis.name
-    awslogs-stream-prefix = "ecs"
+    log_driver = "awslogs"
+    options = {
+      awslogs-region        = data.aws_region.current.name
+      awslogs-group         = aws_cloudwatch_log_group.atlantis.name
+      awslogs-stream-prefix = "ecs"
+    }
   }
 
   environment = concat(
@@ -460,9 +463,12 @@ module "container_definition_bitbucket" {
   ]
 
   log_configuration = {
-    awslogs-region        = data.aws_region.current.name
-    awslogs-group         = aws_cloudwatch_log_group.atlantis.name
-    awslogs-stream-prefix = "ecs"
+    log_driver = "awslogs"
+    options = {
+      awslogs-region        = data.aws_region.current.name
+      awslogs-group         = aws_cloudwatch_log_group.atlantis.name
+      awslogs-stream-prefix = "ecs"
+    }
   }
 
   environment = concat(

--- a/main.tf
+++ b/main.tf
@@ -405,7 +405,7 @@ resource "aws_iam_role_policy" "ecs_task_access_secrets" {
 
 module "container_definition_github_gitlab" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "v0.15.0"
+  version = "v0.21.0"
 
   container_name  = var.name
   container_image = local.atlantis_image
@@ -442,7 +442,7 @@ module "container_definition_github_gitlab" {
 
 module "container_definition_bitbucket" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "v0.15.0"
+  version = "v0.21.0"
 
   container_name  = var.name
   container_image = local.atlantis_image

--- a/main.tf
+++ b/main.tf
@@ -422,10 +422,10 @@ module "container_definition_github_gitlab" {
     },
   ]
 
-  log_options = {
-    "awslogs-region"        = data.aws_region.current.name
-    "awslogs-group"         = aws_cloudwatch_log_group.atlantis.name
-    "awslogs-stream-prefix" = "ecs"
+  log_configuration = {
+    awslogs-region        = data.aws_region.current.name
+    awslogs-group         = aws_cloudwatch_log_group.atlantis.name
+    awslogs-stream-prefix = "ecs"
   }
 
   environment = concat(
@@ -459,10 +459,10 @@ module "container_definition_bitbucket" {
     },
   ]
 
-  log_options = {
-    "awslogs-region"        = data.aws_region.current.name
-    "awslogs-group"         = aws_cloudwatch_log_group.atlantis.name
-    "awslogs-stream-prefix" = "ecs"
+  log_configuration = {
+    awslogs-region        = data.aws_region.current.name
+    awslogs-group         = aws_cloudwatch_log_group.atlantis.name
+    awslogs-stream-prefix = "ecs"
   }
 
   environment = concat(


### PR DESCRIPTION
# Description

The module sub-module "cloudposse/ecs-container-definition/aws" version "v0.15.0" causes multiple warnings when using TF 0.12 - "Warning: Quoted type constraints are deprecated"

This updates that module to v0.21.0 and one attribute change.

From

> source  = "cloudposse/ecs-container-definition/aws"
> version = "v0.15.0"
> attribute = "log_options {..}"

To

> source  = "cloudposse/ecs-container-definition/aws"
> version = "v0.21.0"
> attribute = "log_configuration {...}" 

