### PR TITLE
Expose ECS service security group as ouptut

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ If all provided subnets are public (no NAT gateway) then `ecs_service_assign_pub
 | task\_role\_arn | The Atlantis ECS task role arn |
 | vpc\_id | ID of the VPC that was created or passed in |
 | webhook\_secret | Webhook secret |
+| ecs\_security\_group | Security group assigned to ECS Service in network configuration |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,8 @@ output "ecs_task_definition" {
   description = "Task definition for ECS service (used for external triggers)"
   value       = aws_ecs_service.atlantis.task_definition
 }
+
+output "ecs_security_group" {
+  description = "Security group assigned to ECS Service in network configuration"
+  value       = module.atlantis_sg.this_security_group_id
+}


### PR DESCRIPTION
# Description

This can be used to configure network rules for traffic coming from
Atlantis
