### PR TITLE
Allow specifying Atlantis command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ If all provided subnets are public (no NAT gateway) then `ecs_service_assign_pub
 | atlantis\_bitbucket\_user | Bitbucket username that is running the Atlantis command | string | `""` | no |
 | atlantis\_bitbucket\_user\_token | Bitbucket token of the user that is running the Atlantis command | string | `""` | no |
 | atlantis\_bitbucket\_user\_token\_ssm\_parameter\_name | Name of SSM parameter to keep atlantis_bitbucket_user_token | string | `"/atlantis/bitbucket/user/token"` | no |
+| atlantis\_command\_line | Command to invoke when running the Atlantis container (as a list of command line items) | list(string) | `["server"]` | no |
 | atlantis\_github\_user | GitHub username that is running the Atlantis command | string | `""` | no |
 | atlantis\_github\_user\_token | GitHub token of the user that is running the Atlantis command | string | `""` | no |
 | atlantis\_github\_user\_token\_ssm\_parameter\_name | Name of SSM parameter to keep atlantis_github_user_token | string | `"/atlantis/github/user/token"` | no |

--- a/main.tf
+++ b/main.tf
@@ -414,6 +414,8 @@ module "container_definition_github_gitlab" {
   container_memory             = var.ecs_task_memory
   container_memory_reservation = var.container_memory_reservation
 
+  command = var.atlantis_command_line
+
   port_mappings = [
     {
       containerPort = var.atlantis_port
@@ -450,6 +452,8 @@ module "container_definition_bitbucket" {
   container_cpu                = var.ecs_task_cpu
   container_memory             = var.ecs_task_memory
   container_memory_reservation = var.container_memory_reservation
+
+  command = var.atlantis_command_line
 
   port_mappings = [
     {

--- a/variables.tf
+++ b/variables.tf
@@ -301,3 +301,9 @@ variable "aws_ssm_path" {
   type        = string
   default     = "aws"
 }
+
+variable "atlantis_command_line" {
+  description = "Command to invoke when running the Atlantis container (as a list of command line items)"
+  type        = list(string)
+  default     = ["server"]
+}


### PR DESCRIPTION
# Description

Allow specifying `CMD` for the Atlantis container inside Fargate.

This is useful if you want to set [custom flags](https://www.runatlantis.io/docs/server-configuration.html#flags) for the Atlantis server process.
