### PR TITLE
Gets rid of deprecation warning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -224,8 +224,9 @@ resource "aws_lb_listener_rule" "redirect_http_to_https" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["*"]
+    path_pattern {
+      values = ["*"]
+    }
   }
 }
 


### PR DESCRIPTION
This updates the syntax to 0.12 and gets rid of the deprecation warning 

```
Warning: "condition.0.field": [DEPRECATED] use 'host_header' or 'path_pattern' attribute instead

  on .terraform/modules/atlantis/terraform-aws-modules-terraform-aws-atlantis-e1242e3/main.tf line 213, in resource "aws_lb_listener_rule" "redirect_http_to_https":
 213: resource "aws_lb_listener_rule" "redirect_http_to_https" {



Warning: "condition.0.values": [DEPRECATED] use 'host_header' or 'path_pattern' attribute instead

  on .terraform/modules/atlantis/terraform-aws-modules-terraform-aws-atlantis-e1242e3/main.tf line 213, in resource "aws_lb_listener_rule" "redirect_http_to_https":
 213: resource "aws_lb_listener_rule" "redirect_http_to_https" {
```
