### PR TITLE
feat: Allow setting of Atlantis log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ If all provided subnets are public (no NAT gateway) then `ecs_service_assign_pub
 | atlantis\_gitlab\_user\_token | Gitlab token of the user that is running the Atlantis command | string | `""` | no |
 | atlantis\_gitlab\_user\_token\_ssm\_parameter\_name | Name of SSM parameter to keep atlantis_gitlab_user_token | string | `"/atlantis/gitlab/user/token"` | no |
 | atlantis\_image | Docker image to run Atlantis with. If not specified, official Atlantis image will be used | string | `""` | no |
+| atlantis\_log\_level | Log level that Atlantis will run with. Accepted values are: <debug\|info\|warn\|error> | string | `"debug"` | no |
 | atlantis\_port | Local port Atlantis should be running on. Default value is most likely fine. | number | `"4141"` | no |
 | atlantis\_repo\_whitelist | List of allowed repositories Atlantis can be used with | list(string) | n/a | yes |
 | atlantis\_version | Verion of Atlantis to run. If not specified latest will be used | string | `"latest"` | no |

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ locals {
     },
     {
       name  = "ATLANTIS_LOG_LEVEL"
-      value = "debug"
+      value = var.atlantis_log_level
     },
     {
       name  = "ATLANTIS_PORT"

--- a/variables.tf
+++ b/variables.tf
@@ -233,6 +233,12 @@ variable "allow_repo_config" {
   default     = "false"
 }
 
+variable "atlantis_log_level" {
+  description = "Log level that Atlantis will run with. Accepted values are: <debug|info|warn|error>"
+  type        = string
+  default     = "debug"
+}
+
 # Github
 variable "atlantis_github_user" {
   description = "GitHub username that is running the Atlantis command"


### PR DESCRIPTION
# Description

Allows setting of `ATLANTIS_LOG_LEVEL` through a variable.

I've tried submitting this via `custom_environment_variables`, however supplying the same variable twice prompts a redeploy on every apply. 

