### PR TITLE
add private docker repo authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ If all provided subnets are public (no NAT gateway) then `ecs_service_assign_pub
 | tags | A map of tags to use on all resources | map(string) | `{}` | no |
 | vpc\_id | ID of an existing VPC where resources will be created | string | `""` | no |
 | webhook\_ssm\_parameter\_name | Name of SSM parameter to keep webhook secret | string | `"/atlantis/webhook/secret"` | no |
+| repository\_credentials | Container repository credentials; required when using a private repo.  This map currently supports a single key; \"credentialsParameter\", which should be the ARN of a Secrets Manager's secret holding the credentials. (more info: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html) | map(string) | `{}` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -438,6 +438,8 @@ module "container_definition_github_gitlab" {
     local.container_definition_secrets_2,
     var.custom_environment_secrets,
   )
+
+  repository_credentials = var.repository_credentials
 }
 
 module "container_definition_bitbucket" {
@@ -474,6 +476,8 @@ module "container_definition_bitbucket" {
     local.container_definition_secrets_1,
     var.custom_environment_secrets,
   )
+
+  repository_credentials = var.repository_credentials
 }
 
 resource "aws_ecs_task_definition" "atlantis" {

--- a/variables.tf
+++ b/variables.tf
@@ -301,3 +301,11 @@ variable "aws_ssm_path" {
   type        = string
   default     = "aws"
 }
+
+variable "repository_credentials" {
+  type        = "map"
+  description = "Container repository credentials; required when using a private repo.  This map currently supports a single key; \"credentialsParameter\", which should be the ARN of a Secrets Manager's secret holding the credentials. (more info: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html)"
+  default     = {}
+}
+
+


### PR DESCRIPTION
# Description

This PR adds functionality to authenticate to a private docker repo. For https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/101

Allows you to pass in the Secret ARN that contains repository credentials as stated in the documentation for fargate. https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html
