### PR TITLE
Only create ACM cert if creating a Route53 record

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -294,7 +294,7 @@ module "acm" {
   source  = "terraform-aws-modules/acm/aws"
   version = "v2.4.0"
 
-  create_certificate = var.certificate_arn == ""
+  create_certificate = var.certificate_arn == "" && var.create_route53_record
 
   domain_name = var.acm_certificate_domain_name == "" ? join(".", [var.name, var.route53_zone_name]) : var.acm_certificate_domain_name
 


### PR DESCRIPTION
# Description

Only create ACM cert if creating a Route53 record