### PR TITLE
feat: Allow custom Route53 record name (including empty)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ No requirements.
 | private\_subnets | A list of private subnets inside the VPC | `list(string)` | `[]` | no |
 | public\_subnet\_ids | A list of IDs of existing public subnets inside the VPC | `list(string)` | `[]` | no |
 | public\_subnets | A list of public subnets inside the VPC | `list(string)` | `[]` | no |
+| route53\_record\_name | Name of Route53 record to create ACM certificate in and main A-record. If null is specified, var.name is used instead. Provide empty string to point root domain name to ALB. | `string` | `null` | no |
 | route53\_zone\_name | Route53 zone name to create ACM certificate in and main A-record, without trailing dot | `string` | `""` | no |
 | security\_group\_ids | List of one or more security groups to be added to the load balancer | `list(string)` | `[]` | no |
 | ssm\_kms\_key\_arn | ARN of KMS key to use for encryption and decryption of SSM Parameters. Required only if your key uses a custom KMS key and not the default key | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -291,7 +291,7 @@ resource "aws_route53_record" "atlantis" {
   count = var.create_route53_record ? 1 : 0
 
   zone_id = data.aws_route53_zone.this[0].zone_id
-  name    = var.name
+  name    = var.route53_record_name != null ? var.route53_record_name : var.name
   type    = "A"
 
   alias {

--- a/variables.tf
+++ b/variables.tf
@@ -110,6 +110,12 @@ variable "route53_zone_name" {
   default     = ""
 }
 
+variable "route53_record_name" {
+  description = "Name of Route53 record to create ACM certificate in and main A-record. If null is specified, var.name is used instead. Provide empty string to point root domain name to ALB."
+  type        = string
+  default     = null
+}
+
 variable "create_route53_record" {
   description = "Whether to create Route53 record for Atlantis"
   type        = bool


### PR DESCRIPTION
Example - Make Atlantis available on the root domain:

```
  route53_zone_name = "atlantis.domain.com"
  route53_record_name = ""

  acm_certificate_domain_name = "atlantis.domain.com"
```