### PR TITLE
Fix issue #72 task_definition known after apply

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -501,19 +501,10 @@ resource "aws_ecs_task_definition" "atlantis" {
   tags = local.tags
 }
 
-data "aws_ecs_task_definition" "atlantis" {
-  task_definition = var.name
-
-  depends_on = [aws_ecs_task_definition.atlantis]
-}
-
 resource "aws_ecs_service" "atlantis" {
   name    = var.name
   cluster = module.ecs.this_ecs_cluster_id
-  task_definition = "${data.aws_ecs_task_definition.atlantis.family}:${max(
-    aws_ecs_task_definition.atlantis.revision,
-    data.aws_ecs_task_definition.atlantis.revision,
-  )}"
+  task_definition = "${aws_ecs_task_definition.atlantis.family}:${aws_ecs_task_definition.atlantis.revision}"
   desired_count                      = var.ecs_service_desired_count
   launch_type                        = "FARGATE"
   deployment_maximum_percent         = var.ecs_service_deployment_maximum_percent


### PR DESCRIPTION
## Description
Using a data provider means terraform doesn't have the information required until runtime to determine if the `task_definition` needs to be updated. Subsequently an update is triggered on every `apply`. It has the information locally already, by removing the indirection of a data provider terraform can correctly reconcile if any updates are required prior to `apply` being run. Essentially it's making the dependency between the `aws_ecs_service` and `aws_ecs_task_definition` explicit rather than implied through the `data` provider and `depends_on`

https://www.terraform.io/docs/configuration/data-sources.html#data-resource-dependencies

## Motivation and Context
Currently atlantis shows an update everytime a plan or apply is run despite no configuration changes.
https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/72

## Breaking Changes
None that I'm aware of.

## How Has This Been Tested?
- Confirmed that updating the vars that are used in the `task_definition` trigger an update
- Manually create a new task_definition revision and confirm that terraform will role back to the 

AWS, plan/apply and manual changes
