### PR TITLE
Add a configuration for the Github Hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ No requirements.
 | atlantis\_bitbucket\_user\_token | Bitbucket token of the user that is running the Atlantis command | `string` | `""` | no |
 | atlantis\_bitbucket\_user\_token\_ssm\_parameter\_name | Name of SSM parameter to keep atlantis\_bitbucket\_user\_token | `string` | `"/atlantis/bitbucket/user/token"` | no |
 | atlantis\_fqdn | FQDN of Atlantis to use. Set this only to override Route53 and ALB's DNS name. | `string` | `null` | no |
+| atlantis\_github\_hostname | GitHub hostname | `string` | `""` | no |
 | atlantis\_github\_user | GitHub username that is running the Atlantis command | `string` | `""` | no |
 | atlantis\_github\_user\_token | GitHub token of the user that is running the Atlantis command | `string` | `""` | no |
 | atlantis\_github\_user\_token\_ssm\_parameter\_name | Name of SSM parameter to keep atlantis\_github\_user\_token | `string` | `"/atlantis/github/user/token"` | no |

--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,10 @@ locals {
       value = local.atlantis_url
     },
     {
+      name  = "ATLANTIS_GH_HOSTNAME"
+      value = var.atlantis_github_hostname
+    },
+    {
       name  = "ATLANTIS_GH_USER"
       value = var.atlantis_github_user
     },

--- a/variables.tf
+++ b/variables.tf
@@ -294,6 +294,12 @@ variable "atlantis_log_level" {
 }
 
 # Github
+variable "atlantis_github_hostname" {
+  description = "GitHub hostname (for on-prem installations)"
+  type        = string
+  default     = ""
+}
+
 variable "atlantis_github_user" {
   description = "GitHub username that is running the Atlantis command"
   type        = string


### PR DESCRIPTION
## Description
This adds a variable to the module to allow targeting an on-prem installation of Github Enterprise. 

## Motivation and Context
Using this with enterprise requires manually injecting an environment variable. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
