### PR TITLE
feat: Add ability to specify existing ALB security groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ No requirements.
 | acm\_certificate\_domain\_name | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance. Specify if it is different from value in `route53_zone_name` | `string` | `""` | no |
 | alb\_authenticate\_oidc | Map of Authenticate OIDC parameters to protect ALB (eg, using Auth0). See https://www.terraform.io/docs/providers/aws/r/lb_listener.html#authenticate-oidc-action | `any` | `{}` | no |
 | alb\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules of the ALB. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| alb\_http\_security\_group\_id | Existing security group with HTTP ports open for specific IPv4 CIDR block (or everybody), egress ports are all world open | `string` | "" | no |
+| alb\_https\_security\_group\_id | Existing security group with HTTPS ports open for specific IPv4 CIDR block (or everybody), egress ports are all world open | `string` | "" | no |
+| atlantis\_security\_group\_id | Existing security group with open port for Atlantis (var.atlantis_port) from ALB, egress ports are all world open | `string` | "" | no |
 | alb\_log\_bucket\_name | S3 bucket (externally created) for storing load balancer access logs. Required if alb\_logging\_enabled is true. | `string` | `""` | no |
 | alb\_log\_location\_prefix | S3 prefix within the log\_bucket\_name under which logs are stored. | `string` | `""` | no |
 | alb\_logging\_enabled | Controls if the ALB will log requests to S3. | `bool` | `false` | no |

--- a/outputs.tf
+++ b/outputs.tf
@@ -45,5 +45,5 @@ output "ecs_task_definition" {
 
 output "ecs_security_group" {
   description = "Security group assigned to ECS Service in network configuration"
-  value       = module.atlantis_sg.this_security_group_id
+  value       = local.atlantis_security_group_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -126,6 +126,25 @@ variable "whitelist_unauthenticated_cidr_blocks" {
   default     = []
 }
 
+# Security Groups
+variable "alb_http_security_group_id" {
+  description = "Existing security group with HTTP ports open for specific IPv4 CIDR block (or everybody), egress ports are all world open"
+  type        = string
+  default     = ""
+}
+
+variable "alb_https_security_group_id" {
+  description = "Existing security group with HTTPS ports open for specific IPv4 CIDR block (or everybody), egress ports are all world open"
+  type        = string
+  default     = ""
+}
+
+variable "atlantis_security_group_id" {
+  description = "Existing security group with open port for Atlantis (var.atlantis_port) from ALB, egress ports are all world open"
+  type        = string
+  default     = ""
+}
+
 # ACM
 variable "certificate_arn" {
   description = "ARN of certificate issued by AWS ACM. If empty, a new ACM certificate will be created and validated using Route53 DNS"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add ability to specify existing security groups for `alb_http_sg`, `alb_https_sg` or `atlantis_sg`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allow module to be used in scenarios where security groups cannot be created or already exist.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```HCL
module "atlantis" {
  ...

  alb_http_security_group_id  = "sg-xxxxxxxxxxxxxxxx1"
  alb_https_security_group_id = "sg-xxxxxxxxxxxxxxxx1"
  atlantis_security_group_id  = "sg-xxxxxxxxxxxxxxxx2"
}
```