### PR TITLE
feat: add ability to specify existing IAM role for ECS task execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ allow_github_webhooks        = true
 | ecs\_service\_deployment\_minimum\_healthy\_percent | The lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment | `number` | `50` | no |
 | ecs\_service\_desired\_count | The number of instances of the task definition to place and keep running | `number` | `1` | no |
 | ecs\_task\_cpu | The number of cpu units used by the task | `number` | `256` | no |
+| ecs\_task\_execution\_iam\_role\_arn | ARN of existing IAM role to use for ECS task execution | `string` | `""` | no |
 | ecs\_task\_memory | The amount (in MiB) of memory used by the task | `number` | `512` | no |
 | entrypoint | The entry point that is passed to the container | `list(string)` | `null` | no |
 | essential | Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value | `bool` | `true` | no |

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,7 +22,7 @@ output "webhook_secret" {
 # ECS
 output "task_role_arn" {
   description = "The Atlantis ECS task role arn"
-  value       = aws_iam_role.ecs_task_execution.arn
+  value       = local.ecs_task_execution_iam_role_arn
 }
 
 output "task_role_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -365,6 +365,10 @@ variable "firelens_configuration" {
     options = map(string)
   })
   default = null
+variable "ecs_task_execution_iam_role_arn" {
+  description = "ARN of existing IAM role to use for ECS task execution"
+  type        = string
+  default     = ""
 }
 
 # Atlantis


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add ability to specify existing IAM role for ECS task execution.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allow module to be used in scenarios where IAM roles cannot be created or already exist.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```HCL
module "atlantis" {
  ...

  ecs_task_execution_iam_role_arn = "arn:aws:iam::xxxxxxxxxxxx:role/xxxxxxxxxx"
}
```
