### PR TITLE
fix: upgrade cloudposse/ecs-container-definition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -431,7 +431,7 @@ resource "aws_iam_role_policy" "ecs_task_access_secrets" {
 
 module "container_definition_github_gitlab" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "v0.23.0"
+  version = "v0.31.0"
 
   container_name  = var.name
   container_image = local.atlantis_image
@@ -472,7 +472,7 @@ module "container_definition_github_gitlab" {
 
 module "container_definition_bitbucket" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "v0.23.0"
+  version = "v0.31.0"
 
   container_name  = var.name
   container_image = local.atlantis_image


### PR DESCRIPTION
## Description
Upgraded cloudposse/ecs-container-definition from 0.23.0 to 0.31.0

## Motivation and Context
This will now reduce the differences in the container definition thanks to [version 0.30.0](https://github.com/cloudposse/terraform-aws-ecs-container-definition/releases)

## Breaking Changes
Some defaults like startTimeout and stopTimeout are set to null.

## How Has This Been Tested?
Changed the version locally, reinitialized, and applied.
