### PR TITLE
feat: Refactor to use SSM ARNs directly from resources

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.30.0
+    rev: v1.31.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -205,7 +205,6 @@ No requirements.
 | atlantis\_port | Local port Atlantis should be running on. Default value is most likely fine. | `number` | `4141` | no |
 | atlantis\_repo\_whitelist | List of allowed repositories Atlantis can be used with | `list(string)` | n/a | yes |
 | atlantis\_version | Verion of Atlantis to run. If not specified latest will be used | `string` | `"latest"` | no |
-| aws\_ssm\_path | AWS ARN prefix for SSM (public AWS region or Govcloud). Valid options: aws, aws-us-gov. | `string` | `"aws"` | no |
 | azs | A list of availability zones in the region | `list(string)` | `[]` | no |
 | certificate\_arn | ARN of certificate issued by AWS ACM. If empty, a new ACM certificate will be created and validated using Route53 DNS | `string` | `""` | no |
 | cidr | The CIDR block for the VPC which will be created if `vpc_id` is not specified | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -382,11 +382,11 @@ data "aws_iam_policy_document" "ecs_task_access_secrets" {
   statement {
     effect = "Allow"
 
-    resources = coalescelist(
+    resources = flatten(list(
       aws_ssm_parameter.webhook.*.arn,
       aws_ssm_parameter.atlantis_github_user_token.*.arn,
       aws_ssm_parameter.atlantis_gitlab_user_token.*.arn,
-    aws_ssm_parameter.atlantis_bitbucket_user_token.*.arn)
+    aws_ssm_parameter.atlantis_bitbucket_user_token.*.arn))
 
     actions = [
       "ssm:GetParameters",

--- a/main.tf
+++ b/main.tf
@@ -98,8 +98,6 @@ locals {
 
 data "aws_region" "current" {}
 
-data "aws_caller_identity" "current" {}
-
 data "aws_route53_zone" "this" {
   count = var.create_route53_record ? 1 : 0
 
@@ -384,12 +382,11 @@ data "aws_iam_policy_document" "ecs_task_access_secrets" {
   statement {
     effect = "Allow"
 
-    resources = [
-      "arn:${var.aws_ssm_path}:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${var.webhook_ssm_parameter_name}",
-      "arn:${var.aws_ssm_path}:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${var.atlantis_github_user_token_ssm_parameter_name}",
-      "arn:${var.aws_ssm_path}:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${var.atlantis_gitlab_user_token_ssm_parameter_name}",
-      "arn:${var.aws_ssm_path}:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${var.atlantis_bitbucket_user_token_ssm_parameter_name}",
-    ]
+    resources = coalescelist(
+      aws_ssm_parameter.webhook.*.arn,
+      aws_ssm_parameter.atlantis_github_user_token.*.arn,
+      aws_ssm_parameter.atlantis_gitlab_user_token.*.arn,
+      aws_ssm_parameter.atlantis_bitbucket_user_token.*.arn)
 
     actions = [
       "ssm:GetParameters",

--- a/main.tf
+++ b/main.tf
@@ -386,7 +386,7 @@ data "aws_iam_policy_document" "ecs_task_access_secrets" {
       aws_ssm_parameter.webhook.*.arn,
       aws_ssm_parameter.atlantis_github_user_token.*.arn,
       aws_ssm_parameter.atlantis_gitlab_user_token.*.arn,
-      aws_ssm_parameter.atlantis_bitbucket_user_token.*.arn)
+    aws_ssm_parameter.atlantis_bitbucket_user_token.*.arn)
 
     actions = [
       "ssm:GetParameters",

--- a/variables.tf
+++ b/variables.tf
@@ -377,9 +377,3 @@ variable "security_group_ids" {
   type        = list(string)
   default     = []
 }
-
-variable "aws_ssm_path" {
-  description = "AWS ARN prefix for SSM (public AWS region or Govcloud). Valid options: aws, aws-us-gov."
-  type        = string
-  default     = "aws"
-}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
remove the `aws_ssm_path` variable to get full proper ARN from SSM resources instead of building it manually

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
NONE

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run with the sample tfvars, added the changes and re-run to get no diffs (aside from regular ECS diff)