### PR TITLE
feat: Add tags to aws_ecs_service resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -550,6 +550,8 @@ resource "aws_ecs_service" "atlantis" {
     container_port   = var.atlantis_port
     target_group_arn = element(module.alb.target_group_arns, 0)
   }
+    
+  tags = local.tags
 }
 
 ###################


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Includes the `local.tags` in the `aws_ecs_service` resource.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For consistency, tags should be used across all the compatible resources created by the module. `aws_ecs_service` seems to be the only resource missing tags.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
`no`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`applied locally`