### PR TITLE
feat: Allow hide-prev-plan-comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ No requirements.
 | ecs\_service\_desired\_count | The number of instances of the task definition to place and keep running | `number` | `1` | no |
 | ecs\_task\_cpu | The number of cpu units used by the task | `number` | `256` | no |
 | ecs\_task\_memory | The amount (in MiB) of memory used by the task | `number` | `512` | no |
+| hide\_prev\_github\_plan\_comments | Enables atlantis server --hide-prev-plan-comments hiding previous plan comments on update | `bool` | `false` | no |
 | github\_webhooks\_cidr\_blocks | List of CIDR blocks used by GitHub webhooks | `list(string)` | <pre>[<br>  "140.82.112.0/20",<br>  "185.199.108.0/22",<br>  "192.30.252.0/22"<br>]</pre> | no |
 | internal | Whether the load balancer is internal or external | `bool` | `false` | no |
 | name | Name to use on all resources created (VPC, ALB, etc) | `string` | `"atlantis"` | no |

--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ No requirements.
 | ecs\_service\_desired\_count | The number of instances of the task definition to place and keep running | `number` | `1` | no |
 | ecs\_task\_cpu | The number of cpu units used by the task | `number` | `256` | no |
 | ecs\_task\_memory | The amount (in MiB) of memory used by the task | `number` | `512` | no |
-| hide\_prev\_github\_plan\_comments | Enables atlantis server --hide-prev-plan-comments hiding previous plan comments on update | `bool` | `false` | no |
 | github\_webhooks\_cidr\_blocks | List of CIDR blocks used by GitHub webhooks | `list(string)` | <pre>[<br>  "140.82.112.0/20",<br>  "185.199.108.0/22",<br>  "192.30.252.0/22"<br>]</pre> | no |
+| hide\_prev\_github\_plan\_comments | Enables atlantis server --hide-prev-plan-comments hiding previous plan comments on update | `bool` | `false` | no |
 | internal | Whether the load balancer is internal or external | `bool` | `false` | no |
 | name | Name to use on all resources created (VPC, ALB, etc) | `string` | `"atlantis"` | no |
 | policies\_arn | A list of the ARN of the policies you want to apply | `list(string)` | <pre>[<br>  "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"<br>]</pre> | no |

--- a/main.tf
+++ b/main.tf
@@ -70,6 +70,10 @@ locals {
       name  = "ATLANTIS_REPO_WHITELIST"
       value = join(",", var.atlantis_repo_whitelist)
     },
+    {
+      name  = "ATLANTIS_HIDE_PREV_PLAN_COMMENTS"
+      value = var.hide_prev_github_plan_comments
+    },
   ]
 
   # Secret access tokens

--- a/variables.tf
+++ b/variables.tf
@@ -377,3 +377,9 @@ variable "security_group_ids" {
   type        = list(string)
   default     = []
 }
+
+variable "hide_prev_github_plan_comments" {
+  description = "Enables atlantis server --hide-prev-plan-comments hiding previous plan comments on update"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Description
Allows users to pass `hide_prev_github_plan_comments` to enable `--hide-prev-plans-comments` that was introduced to atlantis in https://github.com/runatlantis/atlantis/commit/782501b8e913bca1f7a490dfa40e3c1963ab81f9

## Motivation and Context
It would be nice to add this implementation into the terraform module so that we can hide the previous plan comments that atlantis posts to github pull requests.  If a PR has been worked on for a long period, many `atlantis plans` may be run, and these comments will continuously be added, making it harder to look for the latest plan, and in general creating noise in the comments on the PR, the old plans would be outdated so they really dont need to show.

This is probably why the atlantis folks initially had this always hide github comments, until that change in the link above.

## Breaking Changes
This does not break any backwards compatibility as it is implementing a New Environment Variable into an Existing List of environment variables to be consumed by the atlantis server here 

https://github.com/runatlantis/atlantis/blob/c70dd5f29652e397b29fc4096df9127b5e02664d/cmd/server.go#L396-L401

This uses the same methodology this repo currently uses in order to pass these environment variable overrides to `viper.AutomaticEnv`

## How Has This Been Tested?
Will post more updates when I deploy this in my own environment.  These are all existing lists and again this uses the exact same methods that are currently used to pass environment variable overrides into atlantis server
