### PR TITLE
feat: Additional tags to wide open security groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ allow_github_webhooks        = true
 | acm\_certificate\_domain\_name | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance. Specify if it is different from value in `route53_zone_name` | `string` | `""` | no |
 | alb\_authenticate\_cognito | Map of AWS Cognito authentication parameters to protect ALB (eg, using SAML). See https://www.terraform.io/docs/providers/aws/r/lb_listener.html#authenticate-cognito-action | `any` | `{}` | no |
 | alb\_authenticate\_oidc | Map of Authenticate OIDC parameters to protect ALB (eg, using Auth0). See https://www.terraform.io/docs/providers/aws/r/lb_listener.html#authenticate-oidc-action | `any` | `{}` | no |
+| alb\_http\_security\_group\_tags | Additional tags to put on the http security group | `map(string)` | `{}` | no |
+| alb\_https\_security\_group\_tags | Additional tags to put on the https security group | `map(string)` | `{}` | no |
 | alb\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules of the ALB. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | alb\_log\_bucket\_name | S3 bucket (externally created) for storing load balancer access logs. Required if alb\_logging\_enabled is true. | `string` | `""` | no |
 | alb\_log\_location\_prefix | S3 prefix within the log\_bucket\_name under which logs are stored. | `string` | `""` | no |
@@ -209,6 +211,7 @@ allow_github_webhooks        = true
 | atlantis\_log\_level | Log level that Atlantis will run with. Accepted values are: <debug\|info\|warn\|error> | `string` | `"debug"` | no |
 | atlantis\_port | Local port Atlantis should be running on. Default value is most likely fine. | `number` | `4141` | no |
 | atlantis\_repo\_whitelist | List of allowed repositories Atlantis can be used with | `list(string)` | n/a | yes |
+| atlantis\_security\_group\_tags | Additional tags to put on the atlantis security group | `map(string)` | `{}` | no |
 | atlantis\_version | Verion of Atlantis to run. If not specified latest will be used | `string` | `"latest"` | no |
 | azs | A list of availability zones in the region | `list(string)` | `[]` | no |
 | certificate\_arn | ARN of certificate issued by AWS ACM. If empty, a new ACM certificate will be created and validated using Route53 DNS | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -246,7 +246,7 @@ module "alb_https_sg" {
 
   ingress_cidr_blocks = var.alb_ingress_cidr_blocks
 
-  tags = local.tags
+  tags = merge(local.tags, var.tags_sgs_additional)
 }
 
 module "alb_http_sg" {
@@ -259,7 +259,7 @@ module "alb_http_sg" {
 
   ingress_cidr_blocks = var.alb_ingress_cidr_blocks
 
-  tags = local.tags
+  tags = merge(local.tags, var.tags_sgs_additional)
 }
 
 module "atlantis_sg" {
@@ -284,7 +284,7 @@ module "atlantis_sg" {
 
   egress_rules = ["all-all"]
 
-  tags = local.tags
+  tags = merge(local.tags, var.tags_sgs_additional)
 }
 
 ###################

--- a/main.tf
+++ b/main.tf
@@ -268,7 +268,7 @@ module "alb_https_sg" {
 
   ingress_cidr_blocks = var.alb_ingress_cidr_blocks
 
-  tags = merge(local.tags, var.tags_sgs_additional)
+  tags = merge(local.tags, var.alb_https_security_group_tags)
 }
 
 module "alb_http_sg" {
@@ -281,7 +281,7 @@ module "alb_http_sg" {
 
   ingress_cidr_blocks = var.alb_ingress_cidr_blocks
 
-  tags = merge(local.tags, var.tags_sgs_additional)
+  tags = merge(local.tags, var.alb_http_security_group_tags)
 }
 
 module "atlantis_sg" {
@@ -304,7 +304,7 @@ module "atlantis_sg" {
 
   egress_rules = ["all-all"]
 
-  tags = merge(local.tags, var.tags_sgs_additional)
+  tags = merge(local.tags, var.atlantis_security_group_tags)
 }
 
 ###################

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "tags_sgs_additional" {
+  description = "Additional tags to put on the security groups that are wide open"
+  type        = map(string)
+  default     = {}
+}
+
 # VPC
 variable "vpc_id" {
   description = "ID of an existing VPC where resources will be created"

--- a/variables.tf
+++ b/variables.tf
@@ -16,8 +16,20 @@ variable "tags" {
   default     = {}
 }
 
-variable "tags_sgs_additional" {
-  description = "Additional tags to put on the security groups that are wide open"
+variable "alb_https_security_group_tags" {
+  description = "Additional tags to put on the https security group"
+  type        = map(string)
+  default     = {}
+}
+
+variable "alb_http_security_group_tags" {
+  description = "Additional tags to put on the http security group"
+  type        = map(string)
+  default     = {}
+}
+
+variable "atlantis_security_group_tags" {
+  description = "Additional tags to put on the atlantis security group"
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
## Description
Adds a new variable `var.tags_sgs_additional` to merge with the tags supplied on the security group resources that are open to the world. This is to add tags to those wide open security groups to pass our audits.

## Motivation and Context
For auditing purposes

Closes https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/141

## Breaking Changes
None

## How Has This Been Tested?
Locally
