### PR TITLE
feat: update container definition including additional parameters to configure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,7 @@ repos:
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
-      - id: terraform_validate
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.1.0
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -164,13 +164,16 @@ allow_github_webhooks        = true
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12.7, < 0.14 |
+| aws | >= 2.68, < 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | >= 2.68, < 4.0 |
 | random | n/a |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -161,82 +161,87 @@ allow_github_webhooks        = true
 * [GitLab repository webhook for Atlantis](https://github.com/terraform-aws-modules/terraform-aws-atlantis/tree/master/examples/gitlab-repository-webhook)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
-
-No requirements.
-
-## Providers
-
-| Name | Version |
-|------|---------|
-| aws | n/a |
-| random | n/a |
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| acm\_certificate\_domain\_name | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance. Specify if it is different from value in `route53_zone_name` | `string` | `""` | no |
-| alb\_authenticate\_cognito | Map of AWS Cognito authentication parameters to protect ALB (eg, using SAML). See https://www.terraform.io/docs/providers/aws/r/lb_listener.html#authenticate-cognito-action | `any` | `{}` | no |
-| alb\_authenticate\_oidc | Map of Authenticate OIDC parameters to protect ALB (eg, using Auth0). See https://www.terraform.io/docs/providers/aws/r/lb_listener.html#authenticate-oidc-action | `any` | `{}` | no |
-| alb\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules of the ALB. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
-| alb\_log\_bucket\_name | S3 bucket (externally created) for storing load balancer access logs. Required if alb\_logging\_enabled is true. | `string` | `""` | no |
-| alb\_log\_location\_prefix | S3 prefix within the log\_bucket\_name under which logs are stored. | `string` | `""` | no |
-| alb\_logging\_enabled | Controls if the ALB will log requests to S3. | `bool` | `false` | no |
-| allow\_github\_webhooks | Whether to allow access for GitHub webhooks | `bool` | `false` | no |
-| allow\_repo\_config | When true allows the use of atlantis.yaml config files within the source repos. | `string` | `"false"` | no |
-| allow\_unauthenticated\_access | Whether to create ALB listener rule to allow unauthenticated access for certain CIDR blocks (eg. allow GitHub webhooks to bypass OIDC authentication) | `bool` | `false` | no |
-| allow\_unauthenticated\_access\_priority | ALB listener rule priority for allow unauthenticated access rule | `number` | `10` | no |
-| atlantis\_allowed\_repo\_names | Git repositories where webhook should be created | `list(string)` | `[]` | no |
-| atlantis\_bitbucket\_base\_url | Base URL of Bitbucket Server, use for Bitbucket on prem (Stash) | `string` | `""` | no |
-| atlantis\_bitbucket\_user | Bitbucket username that is running the Atlantis command | `string` | `""` | no |
-| atlantis\_bitbucket\_user\_token | Bitbucket token of the user that is running the Atlantis command | `string` | `""` | no |
-| atlantis\_bitbucket\_user\_token\_ssm\_parameter\_name | Name of SSM parameter to keep atlantis\_bitbucket\_user\_token | `string` | `"/atlantis/bitbucket/user/token"` | no |
-| atlantis\_fqdn | FQDN of Atlantis to use. Set this only to override Route53 and ALB's DNS name. | `string` | `null` | no |
-| atlantis\_github\_user | GitHub username that is running the Atlantis command | `string` | `""` | no |
-| atlantis\_github\_user\_token | GitHub token of the user that is running the Atlantis command | `string` | `""` | no |
-| atlantis\_github\_user\_token\_ssm\_parameter\_name | Name of SSM parameter to keep atlantis\_github\_user\_token | `string` | `"/atlantis/github/user/token"` | no |
-| atlantis\_gitlab\_hostname | Gitlab server hostname, defaults to gitlab.com | `string` | `"gitlab.com"` | no |
-| atlantis\_gitlab\_user | Gitlab username that is running the Atlantis command | `string` | `""` | no |
-| atlantis\_gitlab\_user\_token | Gitlab token of the user that is running the Atlantis command | `string` | `""` | no |
-| atlantis\_gitlab\_user\_token\_ssm\_parameter\_name | Name of SSM parameter to keep atlantis\_gitlab\_user\_token | `string` | `"/atlantis/gitlab/user/token"` | no |
-| atlantis\_hide\_prev\_plan\_comments | Enables atlantis server --hide-prev-plan-comments hiding previous plan comments on update | `string` | `"false"` | no |
-| atlantis\_image | Docker image to run Atlantis with. If not specified, official Atlantis image will be used | `string` | `""` | no |
-| atlantis\_log\_level | Log level that Atlantis will run with. Accepted values are: <debug\|info\|warn\|error> | `string` | `"debug"` | no |
-| atlantis\_port | Local port Atlantis should be running on. Default value is most likely fine. | `number` | `4141` | no |
-| atlantis\_repo\_whitelist | List of allowed repositories Atlantis can be used with | `list(string)` | n/a | yes |
-| atlantis\_version | Verion of Atlantis to run. If not specified latest will be used | `string` | `"latest"` | no |
-| azs | A list of availability zones in the region | `list(string)` | `[]` | no |
-| certificate\_arn | ARN of certificate issued by AWS ACM. If empty, a new ACM certificate will be created and validated using Route53 DNS | `string` | `""` | no |
-| cidr | The CIDR block for the VPC which will be created if `vpc_id` is not specified | `string` | `""` | no |
-| cloudwatch\_log\_retention\_in\_days | Retention period of Atlantis CloudWatch logs | `number` | `7` | no |
-| container\_memory\_reservation | The amount of memory (in MiB) to reserve for the container | `number` | `128` | no |
-| create\_route53\_record | Whether to create Route53 record for Atlantis | `bool` | `true` | no |
-| custom\_container\_definitions | A list of valid container definitions provided as a single valid JSON document. By default, the standard container definition is used. | `string` | `""` | no |
-| custom\_environment\_secrets | List of additional secrets the container will use (list should contain maps with `name` and `valueFrom`) | <pre>list(object(<br>    {<br>      name      = string<br>      valueFrom = string<br>    }<br>  ))</pre> | `[]` | no |
-| custom\_environment\_variables | List of additional environment variables the container will use (list should contain maps with `name` and `value`) | <pre>list(object(<br>    {<br>      name  = string<br>      value = string<br>    }<br>  ))</pre> | `[]` | no |
-| ecs\_service\_assign\_public\_ip | Should be true, if ECS service is using public subnets (more info: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_cannot_pull_image.html) | `bool` | `false` | no |
-| ecs\_service\_deployment\_maximum\_percent | The upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a service during a deployment | `number` | `200` | no |
-| ecs\_service\_deployment\_minimum\_healthy\_percent | The lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment | `number` | `50` | no |
-| ecs\_service\_desired\_count | The number of instances of the task definition to place and keep running | `number` | `1` | no |
-| ecs\_task\_cpu | The number of cpu units used by the task | `number` | `256` | no |
-| ecs\_task\_memory | The amount (in MiB) of memory used by the task | `number` | `512` | no |
-| github\_webhooks\_cidr\_blocks | List of CIDR blocks used by GitHub webhooks | `list(string)` | <pre>[<br>  "140.82.112.0/20",<br>  "185.199.108.0/22",<br>  "192.30.252.0/22"<br>]</pre> | no |
-| internal | Whether the load balancer is internal or external | `bool` | `false` | no |
-| name | Name to use on all resources created (VPC, ALB, etc) | `string` | `"atlantis"` | no |
-| policies\_arn | A list of the ARN of the policies you want to apply | `list(string)` | <pre>[<br>  "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"<br>]</pre> | no |
-| private\_subnet\_ids | A list of IDs of existing private subnets inside the VPC | `list(string)` | `[]` | no |
-| private\_subnets | A list of private subnets inside the VPC | `list(string)` | `[]` | no |
-| public\_subnet\_ids | A list of IDs of existing public subnets inside the VPC | `list(string)` | `[]` | no |
-| public\_subnets | A list of public subnets inside the VPC | `list(string)` | `[]` | no |
-| route53\_record\_name | Name of Route53 record to create ACM certificate in and main A-record. If null is specified, var.name is used instead. Provide empty string to point root domain name to ALB. | `string` | `null` | no |
-| route53\_zone\_name | Route53 zone name to create ACM certificate in and main A-record, without trailing dot | `string` | `""` | no |
-| security\_group\_ids | List of one or more security groups to be added to the load balancer | `list(string)` | `[]` | no |
-| ssm\_kms\_key\_arn | ARN of KMS key to use for encryption and decryption of SSM Parameters. Required only if your key uses a custom KMS key and not the default key | `string` | `""` | no |
-| tags | A map of tags to use on all resources | `map(string)` | `{}` | no |
-| vpc\_id | ID of an existing VPC where resources will be created | `string` | `""` | no |
-| webhook\_ssm\_parameter\_name | Name of SSM parameter to keep webhook secret | `string` | `"/atlantis/webhook/secret"` | no |
-| whitelist\_unauthenticated\_cidr\_blocks | List of allowed CIDR blocks to bypass authentication | `list(string)` | `[]` | no |
+|------|-------------|:----:|:-----:|:-----:|
+| acm\_certificate\_domain\_name | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance. Specify if it is different from value in `route53\_zone\_name` | string | `""` | no |
+| alb\_authenticate\_cognito | Map of AWS Cognito authentication parameters to protect ALB \(eg, using SAML\). See https://www.terraform.io/docs/providers/aws/r/lb\_listener.html#authenticate-cognito-action | any | `{}` | no |
+| alb\_authenticate\_oidc | Map of Authenticate OIDC parameters to protect ALB \(eg, using Auth0\). See https://www.terraform.io/docs/providers/aws/r/lb\_listener.html#authenticate-oidc-action | any | `{}` | no |
+| alb\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules of the ALB. | list(string) | `[ "0.0.0.0/0" ]` | no |
+| alb\_log\_bucket\_name | S3 bucket \(externally created\) for storing load balancer access logs. Required if alb\_logging\_enabled is true. | string | `""` | no |
+| alb\_log\_location\_prefix | S3 prefix within the log\_bucket\_name under which logs are stored. | string | `""` | no |
+| alb\_logging\_enabled | Controls if the ALB will log requests to S3. | bool | `"false"` | no |
+| allow\_github\_webhooks | Whether to allow access for GitHub webhooks | bool | `"false"` | no |
+| allow\_repo\_config | When true allows the use of atlantis.yaml config files within the source repos. | string | `"false"` | no |
+| allow\_unauthenticated\_access | Whether to create ALB listener rule to allow unauthenticated access for certain CIDR blocks \(eg. allow GitHub webhooks to bypass OIDC authentication\) | bool | `"false"` | no |
+| allow\_unauthenticated\_access\_priority | ALB listener rule priority for allow unauthenticated access rule | number | `"10"` | no |
+| atlantis\_allowed\_repo\_names | Git repositories where webhook should be created | list(string) | `[]` | no |
+| atlantis\_bitbucket\_base\_url | Base URL of Bitbucket Server, use for Bitbucket on prem \(Stash\) | string | `""` | no |
+| atlantis\_bitbucket\_user | Bitbucket username that is running the Atlantis command | string | `""` | no |
+| atlantis\_bitbucket\_user\_token | Bitbucket token of the user that is running the Atlantis command | string | `""` | no |
+| atlantis\_bitbucket\_user\_token\_ssm\_parameter\_name | Name of SSM parameter to keep atlantis\_bitbucket\_user\_token | string | `"/atlantis/bitbucket/user/token"` | no |
+| atlantis\_fqdn | FQDN of Atlantis to use. Set this only to override Route53 and ALB's DNS name. | string | `"null"` | no |
+| atlantis\_github\_user | GitHub username that is running the Atlantis command | string | `""` | no |
+| atlantis\_github\_user\_token | GitHub token of the user that is running the Atlantis command | string | `""` | no |
+| atlantis\_github\_user\_token\_ssm\_parameter\_name | Name of SSM parameter to keep atlantis\_github\_user\_token | string | `"/atlantis/github/user/token"` | no |
+| atlantis\_gitlab\_hostname | Gitlab server hostname, defaults to gitlab.com | string | `"gitlab.com"` | no |
+| atlantis\_gitlab\_user | Gitlab username that is running the Atlantis command | string | `""` | no |
+| atlantis\_gitlab\_user\_token | Gitlab token of the user that is running the Atlantis command | string | `""` | no |
+| atlantis\_gitlab\_user\_token\_ssm\_parameter\_name | Name of SSM parameter to keep atlantis\_gitlab\_user\_token | string | `"/atlantis/gitlab/user/token"` | no |
+| atlantis\_hide\_prev\_plan\_comments | Enables atlantis server --hide-prev-plan-comments hiding previous plan comments on update | string | `"false"` | no |
+| atlantis\_image | Docker image to run Atlantis with. If not specified, official Atlantis image will be used | string | `""` | no |
+| atlantis\_log\_level | Log level that Atlantis will run with. Accepted values are: <debug\|info\|warn\|error> | string | `"debug"` | no |
+| atlantis\_port | Local port Atlantis should be running on. Default value is most likely fine. | number | `"4141"` | no |
+| atlantis\_repo\_whitelist | List of allowed repositories Atlantis can be used with | list(string) | n/a | yes |
+| atlantis\_version | Verion of Atlantis to run. If not specified latest will be used | string | `"latest"` | no |
+| azs | A list of availability zones in the region | list(string) | `[]` | no |
+| certificate\_arn | ARN of certificate issued by AWS ACM. If empty, a new ACM certificate will be created and validated using Route53 DNS | string | `""` | no |
+| cidr | The CIDR block for the VPC which will be created if `vpc\_id` is not specified | string | `""` | no |
+| cloudwatch\_log\_retention\_in\_days | Retention period of Atlantis CloudWatch logs | number | `"7"` | no |
+| command | The command that is passed to the container | list(string) | `"null"` | no |
+| container\_depends\_on | The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed. The condition can be one of START, COMPLETE, SUCCESS or HEALTHY | object | `"null"` | no |
+| container\_memory\_reservation | The amount of memory \(in MiB\) to reserve for the container | number | `"128"` | no |
+| create\_route53\_record | Whether to create Route53 record for Atlantis | bool | `"true"` | no |
+| custom\_container\_definitions | A list of valid container definitions provided as a single valid JSON document. By default, the standard container definition is used. | string | `""` | no |
+| custom\_environment\_secrets | List of additional secrets the container will use \(list should contain maps with `name` and `valueFrom`\) | object | `[]` | no |
+| custom\_environment\_variables | List of additional environment variables the container will use \(list should contain maps with `name` and `value`\) | object | `[]` | no |
+| docker\_labels | The configuration options to send to the `docker\_labels` | map(string) | `"null"` | no |
+| ecs\_container\_insights | Controls if ECS Cluster has container insights enabled | bool | `"false"` | no |
+| ecs\_service\_assign\_public\_ip | Should be true, if ECS service is using public subnets \(more info: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task\_cannot\_pull\_image.html\) | bool | `"false"` | no |
+| ecs\_service\_deployment\_maximum\_percent | The upper limit \(as a percentage of the service's desiredCount\) of the number of running tasks that can be running in a service during a deployment | number | `"200"` | no |
+| ecs\_service\_deployment\_minimum\_healthy\_percent | The lower limit \(as a percentage of the service's desiredCount\) of the number of running tasks that must remain running and healthy in a service during a deployment | number | `"50"` | no |
+| ecs\_service\_desired\_count | The number of instances of the task definition to place and keep running | number | `"1"` | no |
+| ecs\_task\_cpu | The number of cpu units used by the task | number | `"256"` | no |
+| ecs\_task\_memory | The amount \(in MiB\) of memory used by the task | number | `"512"` | no |
+| entrypoint | The entry point that is passed to the container | list(string) | `"null"` | no |
+| essential | Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value | bool | `"true"` | no |
+| firelens\_configuration | The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API\_FirelensConfiguration.html | object | `"null"` | no |
+| github\_webhooks\_cidr\_blocks | List of CIDR blocks used by GitHub webhooks | list(string) | `[ "140.82.112.0/20", "185.199.108.0/22", "192.30.252.0/22" ]` | no |
+| internal | Whether the load balancer is internal or external | bool | `"false"` | no |
+| mount\_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume`. The `readOnly` key is optional. | list | `[]` | no |
+| name | Name to use on all resources created \(VPC, ALB, etc\) | string | `"atlantis"` | no |
+| policies\_arn | A list of the ARN of the policies you want to apply | list(string) | `[ "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy" ]` | no |
+| private\_subnet\_ids | A list of IDs of existing private subnets inside the VPC | list(string) | `[]` | no |
+| private\_subnets | A list of private subnets inside the VPC | list(string) | `[]` | no |
+| public\_subnet\_ids | A list of IDs of existing public subnets inside the VPC | list(string) | `[]` | no |
+| public\_subnets | A list of public subnets inside the VPC | list(string) | `[]` | no |
+| readonly\_root\_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value | bool | `"false"` | no |
+| repository\_credentials | Container repository credentials; required when using a private repo.  This map currently supports a single key; "credentialsParameter", which should be the ARN of a Secrets Manager's secret holding the credentials | map(string) | `"null"` | no |
+| route53\_record\_name | Name of Route53 record to create ACM certificate in and main A-record. If null is specified, var.name is used instead. Provide empty string to point root domain name to ALB. | string | `"null"` | no |
+| route53\_zone\_name | Route53 zone name to create ACM certificate in and main A-record, without trailing dot | string | `""` | no |
+| security\_group\_ids | List of one or more security groups to be added to the load balancer | list(string) | `[]` | no |
+| ssm\_kms\_key\_arn | ARN of KMS key to use for encryption and decryption of SSM Parameters. Required only if your key uses a custom KMS key and not the default key | string | `""` | no |
+| start\_timeout | Time duration \(in seconds\) to wait before giving up on resolving dependencies for a container | number | `"30"` | no |
+| stop\_timeout | Time duration \(in seconds\) to wait before the container is forcefully killed if it doesn't exit normally on its own | number | `"30"` | no |
+| tags | A map of tags to use on all resources | map(string) | `{}` | no |
+| ulimits | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | object | `"null"` | no |
+| user | The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group. The default \(null\) will use the container's configured `USER` directive or root if not set. | string | `"null"` | no |
+| volumes\_from | A list of VolumesFrom maps which contain "sourceContainer" \(name of the container that has the volumes to mount\) and "readOnly" \(whether the container can write to the volume\) | object | `[]` | no |
+| vpc\_id | ID of an existing VPC where resources will be created | string | `""` | no |
+| webhook\_ssm\_parameter\_name | Name of SSM parameter to keep webhook secret | string | `"/atlantis/webhook/secret"` | no |
+| whitelist\_unauthenticated\_cidr\_blocks | List of allowed CIDR blocks to bypass authentication | list(string) | `[]` | no |
+| working\_directory | The working directory to run commands inside the container | string | `"null"` | no |
 
 ## Outputs
 
@@ -248,7 +253,7 @@ No requirements.
 | atlantis\_url | URL of Atlantis |
 | atlantis\_url\_events | Webhook events URL of Atlantis |
 | ecs\_security\_group | Security group assigned to ECS Service in network configuration |
-| ecs\_task\_definition | Task definition for ECS service (used for external triggers) |
+| ecs\_task\_definition | Task definition for ECS service \(used for external triggers\) |
 | task\_role\_arn | The Atlantis ECS task role arn |
 | vpc\_id | ID of the VPC that was created or passed in |
 | webhook\_secret | Webhook secret |

--- a/README.md
+++ b/README.md
@@ -161,87 +161,98 @@ allow_github_webhooks        = true
 * [GitLab repository webhook for Atlantis](https://github.com/terraform-aws-modules/terraform-aws-atlantis/tree/master/examples/gitlab-repository-webhook)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| random | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| acm\_certificate\_domain\_name | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance. Specify if it is different from value in `route53\_zone\_name` | string | `""` | no |
-| alb\_authenticate\_cognito | Map of AWS Cognito authentication parameters to protect ALB \(eg, using SAML\). See https://www.terraform.io/docs/providers/aws/r/lb\_listener.html#authenticate-cognito-action | any | `{}` | no |
-| alb\_authenticate\_oidc | Map of Authenticate OIDC parameters to protect ALB \(eg, using Auth0\). See https://www.terraform.io/docs/providers/aws/r/lb\_listener.html#authenticate-oidc-action | any | `{}` | no |
-| alb\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules of the ALB. | list(string) | `[ "0.0.0.0/0" ]` | no |
-| alb\_log\_bucket\_name | S3 bucket \(externally created\) for storing load balancer access logs. Required if alb\_logging\_enabled is true. | string | `""` | no |
-| alb\_log\_location\_prefix | S3 prefix within the log\_bucket\_name under which logs are stored. | string | `""` | no |
-| alb\_logging\_enabled | Controls if the ALB will log requests to S3. | bool | `"false"` | no |
-| allow\_github\_webhooks | Whether to allow access for GitHub webhooks | bool | `"false"` | no |
-| allow\_repo\_config | When true allows the use of atlantis.yaml config files within the source repos. | string | `"false"` | no |
-| allow\_unauthenticated\_access | Whether to create ALB listener rule to allow unauthenticated access for certain CIDR blocks \(eg. allow GitHub webhooks to bypass OIDC authentication\) | bool | `"false"` | no |
-| allow\_unauthenticated\_access\_priority | ALB listener rule priority for allow unauthenticated access rule | number | `"10"` | no |
-| atlantis\_allowed\_repo\_names | Git repositories where webhook should be created | list(string) | `[]` | no |
-| atlantis\_bitbucket\_base\_url | Base URL of Bitbucket Server, use for Bitbucket on prem \(Stash\) | string | `""` | no |
-| atlantis\_bitbucket\_user | Bitbucket username that is running the Atlantis command | string | `""` | no |
-| atlantis\_bitbucket\_user\_token | Bitbucket token of the user that is running the Atlantis command | string | `""` | no |
-| atlantis\_bitbucket\_user\_token\_ssm\_parameter\_name | Name of SSM parameter to keep atlantis\_bitbucket\_user\_token | string | `"/atlantis/bitbucket/user/token"` | no |
-| atlantis\_fqdn | FQDN of Atlantis to use. Set this only to override Route53 and ALB's DNS name. | string | `"null"` | no |
-| atlantis\_github\_user | GitHub username that is running the Atlantis command | string | `""` | no |
-| atlantis\_github\_user\_token | GitHub token of the user that is running the Atlantis command | string | `""` | no |
-| atlantis\_github\_user\_token\_ssm\_parameter\_name | Name of SSM parameter to keep atlantis\_github\_user\_token | string | `"/atlantis/github/user/token"` | no |
-| atlantis\_gitlab\_hostname | Gitlab server hostname, defaults to gitlab.com | string | `"gitlab.com"` | no |
-| atlantis\_gitlab\_user | Gitlab username that is running the Atlantis command | string | `""` | no |
-| atlantis\_gitlab\_user\_token | Gitlab token of the user that is running the Atlantis command | string | `""` | no |
-| atlantis\_gitlab\_user\_token\_ssm\_parameter\_name | Name of SSM parameter to keep atlantis\_gitlab\_user\_token | string | `"/atlantis/gitlab/user/token"` | no |
-| atlantis\_hide\_prev\_plan\_comments | Enables atlantis server --hide-prev-plan-comments hiding previous plan comments on update | string | `"false"` | no |
-| atlantis\_image | Docker image to run Atlantis with. If not specified, official Atlantis image will be used | string | `""` | no |
-| atlantis\_log\_level | Log level that Atlantis will run with. Accepted values are: <debug\|info\|warn\|error> | string | `"debug"` | no |
-| atlantis\_port | Local port Atlantis should be running on. Default value is most likely fine. | number | `"4141"` | no |
-| atlantis\_repo\_whitelist | List of allowed repositories Atlantis can be used with | list(string) | n/a | yes |
-| atlantis\_version | Verion of Atlantis to run. If not specified latest will be used | string | `"latest"` | no |
-| azs | A list of availability zones in the region | list(string) | `[]` | no |
-| certificate\_arn | ARN of certificate issued by AWS ACM. If empty, a new ACM certificate will be created and validated using Route53 DNS | string | `""` | no |
-| cidr | The CIDR block for the VPC which will be created if `vpc\_id` is not specified | string | `""` | no |
-| cloudwatch\_log\_retention\_in\_days | Retention period of Atlantis CloudWatch logs | number | `"7"` | no |
-| command | The command that is passed to the container | list(string) | `"null"` | no |
-| container\_depends\_on | The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed. The condition can be one of START, COMPLETE, SUCCESS or HEALTHY | object | `"null"` | no |
-| container\_memory\_reservation | The amount of memory \(in MiB\) to reserve for the container | number | `"128"` | no |
-| create\_route53\_record | Whether to create Route53 record for Atlantis | bool | `"true"` | no |
-| custom\_container\_definitions | A list of valid container definitions provided as a single valid JSON document. By default, the standard container definition is used. | string | `""` | no |
-| custom\_environment\_secrets | List of additional secrets the container will use \(list should contain maps with `name` and `valueFrom`\) | object | `[]` | no |
-| custom\_environment\_variables | List of additional environment variables the container will use \(list should contain maps with `name` and `value`\) | object | `[]` | no |
-| docker\_labels | The configuration options to send to the `docker\_labels` | map(string) | `"null"` | no |
-| ecs\_container\_insights | Controls if ECS Cluster has container insights enabled | bool | `"false"` | no |
-| ecs\_service\_assign\_public\_ip | Should be true, if ECS service is using public subnets \(more info: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task\_cannot\_pull\_image.html\) | bool | `"false"` | no |
-| ecs\_service\_deployment\_maximum\_percent | The upper limit \(as a percentage of the service's desiredCount\) of the number of running tasks that can be running in a service during a deployment | number | `"200"` | no |
-| ecs\_service\_deployment\_minimum\_healthy\_percent | The lower limit \(as a percentage of the service's desiredCount\) of the number of running tasks that must remain running and healthy in a service during a deployment | number | `"50"` | no |
-| ecs\_service\_desired\_count | The number of instances of the task definition to place and keep running | number | `"1"` | no |
-| ecs\_task\_cpu | The number of cpu units used by the task | number | `"256"` | no |
-| ecs\_task\_memory | The amount \(in MiB\) of memory used by the task | number | `"512"` | no |
-| entrypoint | The entry point that is passed to the container | list(string) | `"null"` | no |
-| essential | Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value | bool | `"true"` | no |
-| firelens\_configuration | The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API\_FirelensConfiguration.html | object | `"null"` | no |
-| github\_webhooks\_cidr\_blocks | List of CIDR blocks used by GitHub webhooks | list(string) | `[ "140.82.112.0/20", "185.199.108.0/22", "192.30.252.0/22" ]` | no |
-| internal | Whether the load balancer is internal or external | bool | `"false"` | no |
-| mount\_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume`. The `readOnly` key is optional. | list | `[]` | no |
-| name | Name to use on all resources created \(VPC, ALB, etc\) | string | `"atlantis"` | no |
-| policies\_arn | A list of the ARN of the policies you want to apply | list(string) | `[ "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy" ]` | no |
-| private\_subnet\_ids | A list of IDs of existing private subnets inside the VPC | list(string) | `[]` | no |
-| private\_subnets | A list of private subnets inside the VPC | list(string) | `[]` | no |
-| public\_subnet\_ids | A list of IDs of existing public subnets inside the VPC | list(string) | `[]` | no |
-| public\_subnets | A list of public subnets inside the VPC | list(string) | `[]` | no |
-| readonly\_root\_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value | bool | `"false"` | no |
-| repository\_credentials | Container repository credentials; required when using a private repo.  This map currently supports a single key; "credentialsParameter", which should be the ARN of a Secrets Manager's secret holding the credentials | map(string) | `"null"` | no |
-| route53\_record\_name | Name of Route53 record to create ACM certificate in and main A-record. If null is specified, var.name is used instead. Provide empty string to point root domain name to ALB. | string | `"null"` | no |
-| route53\_zone\_name | Route53 zone name to create ACM certificate in and main A-record, without trailing dot | string | `""` | no |
-| security\_group\_ids | List of one or more security groups to be added to the load balancer | list(string) | `[]` | no |
-| ssm\_kms\_key\_arn | ARN of KMS key to use for encryption and decryption of SSM Parameters. Required only if your key uses a custom KMS key and not the default key | string | `""` | no |
-| start\_timeout | Time duration \(in seconds\) to wait before giving up on resolving dependencies for a container | number | `"30"` | no |
-| stop\_timeout | Time duration \(in seconds\) to wait before the container is forcefully killed if it doesn't exit normally on its own | number | `"30"` | no |
-| tags | A map of tags to use on all resources | map(string) | `{}` | no |
-| ulimits | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | object | `"null"` | no |
-| user | The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group. The default \(null\) will use the container's configured `USER` directive or root if not set. | string | `"null"` | no |
-| volumes\_from | A list of VolumesFrom maps which contain "sourceContainer" \(name of the container that has the volumes to mount\) and "readOnly" \(whether the container can write to the volume\) | object | `[]` | no |
-| vpc\_id | ID of an existing VPC where resources will be created | string | `""` | no |
-| webhook\_ssm\_parameter\_name | Name of SSM parameter to keep webhook secret | string | `"/atlantis/webhook/secret"` | no |
-| whitelist\_unauthenticated\_cidr\_blocks | List of allowed CIDR blocks to bypass authentication | list(string) | `[]` | no |
-| working\_directory | The working directory to run commands inside the container | string | `"null"` | no |
+|------|-------------|------|---------|:--------:|
+| acm\_certificate\_domain\_name | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance. Specify if it is different from value in `route53_zone_name` | `string` | `""` | no |
+| alb\_authenticate\_cognito | Map of AWS Cognito authentication parameters to protect ALB (eg, using SAML). See https://www.terraform.io/docs/providers/aws/r/lb_listener.html#authenticate-cognito-action | `any` | `{}` | no |
+| alb\_authenticate\_oidc | Map of Authenticate OIDC parameters to protect ALB (eg, using Auth0). See https://www.terraform.io/docs/providers/aws/r/lb_listener.html#authenticate-oidc-action | `any` | `{}` | no |
+| alb\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules of the ALB. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| alb\_log\_bucket\_name | S3 bucket (externally created) for storing load balancer access logs. Required if alb\_logging\_enabled is true. | `string` | `""` | no |
+| alb\_log\_location\_prefix | S3 prefix within the log\_bucket\_name under which logs are stored. | `string` | `""` | no |
+| alb\_logging\_enabled | Controls if the ALB will log requests to S3. | `bool` | `false` | no |
+| allow\_github\_webhooks | Whether to allow access for GitHub webhooks | `bool` | `false` | no |
+| allow\_repo\_config | When true allows the use of atlantis.yaml config files within the source repos. | `string` | `"false"` | no |
+| allow\_unauthenticated\_access | Whether to create ALB listener rule to allow unauthenticated access for certain CIDR blocks (eg. allow GitHub webhooks to bypass OIDC authentication) | `bool` | `false` | no |
+| allow\_unauthenticated\_access\_priority | ALB listener rule priority for allow unauthenticated access rule | `number` | `10` | no |
+| atlantis\_allowed\_repo\_names | Git repositories where webhook should be created | `list(string)` | `[]` | no |
+| atlantis\_bitbucket\_base\_url | Base URL of Bitbucket Server, use for Bitbucket on prem (Stash) | `string` | `""` | no |
+| atlantis\_bitbucket\_user | Bitbucket username that is running the Atlantis command | `string` | `""` | no |
+| atlantis\_bitbucket\_user\_token | Bitbucket token of the user that is running the Atlantis command | `string` | `""` | no |
+| atlantis\_bitbucket\_user\_token\_ssm\_parameter\_name | Name of SSM parameter to keep atlantis\_bitbucket\_user\_token | `string` | `"/atlantis/bitbucket/user/token"` | no |
+| atlantis\_fqdn | FQDN of Atlantis to use. Set this only to override Route53 and ALB's DNS name. | `string` | `null` | no |
+| atlantis\_github\_user | GitHub username that is running the Atlantis command | `string` | `""` | no |
+| atlantis\_github\_user\_token | GitHub token of the user that is running the Atlantis command | `string` | `""` | no |
+| atlantis\_github\_user\_token\_ssm\_parameter\_name | Name of SSM parameter to keep atlantis\_github\_user\_token | `string` | `"/atlantis/github/user/token"` | no |
+| atlantis\_gitlab\_hostname | Gitlab server hostname, defaults to gitlab.com | `string` | `"gitlab.com"` | no |
+| atlantis\_gitlab\_user | Gitlab username that is running the Atlantis command | `string` | `""` | no |
+| atlantis\_gitlab\_user\_token | Gitlab token of the user that is running the Atlantis command | `string` | `""` | no |
+| atlantis\_gitlab\_user\_token\_ssm\_parameter\_name | Name of SSM parameter to keep atlantis\_gitlab\_user\_token | `string` | `"/atlantis/gitlab/user/token"` | no |
+| atlantis\_hide\_prev\_plan\_comments | Enables atlantis server --hide-prev-plan-comments hiding previous plan comments on update | `string` | `"false"` | no |
+| atlantis\_image | Docker image to run Atlantis with. If not specified, official Atlantis image will be used | `string` | `""` | no |
+| atlantis\_log\_level | Log level that Atlantis will run with. Accepted values are: <debug\|info\|warn\|error> | `string` | `"debug"` | no |
+| atlantis\_port | Local port Atlantis should be running on. Default value is most likely fine. | `number` | `4141` | no |
+| atlantis\_repo\_whitelist | List of allowed repositories Atlantis can be used with | `list(string)` | n/a | yes |
+| atlantis\_version | Verion of Atlantis to run. If not specified latest will be used | `string` | `"latest"` | no |
+| azs | A list of availability zones in the region | `list(string)` | `[]` | no |
+| certificate\_arn | ARN of certificate issued by AWS ACM. If empty, a new ACM certificate will be created and validated using Route53 DNS | `string` | `""` | no |
+| cidr | The CIDR block for the VPC which will be created if `vpc_id` is not specified | `string` | `""` | no |
+| cloudwatch\_log\_retention\_in\_days | Retention period of Atlantis CloudWatch logs | `number` | `7` | no |
+| command | The command that is passed to the container | `list(string)` | `null` | no |
+| container\_depends\_on | The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed. The condition can be one of START, COMPLETE, SUCCESS or HEALTHY | <pre>list(object({<br>    containerName = string<br>    condition     = string<br>  }))</pre> | `null` | no |
+| container\_memory\_reservation | The amount of memory (in MiB) to reserve for the container | `number` | `128` | no |
+| create\_route53\_record | Whether to create Route53 record for Atlantis | `bool` | `true` | no |
+| custom\_container\_definitions | A list of valid container definitions provided as a single valid JSON document. By default, the standard container definition is used. | `string` | `""` | no |
+| custom\_environment\_secrets | List of additional secrets the container will use (list should contain maps with `name` and `valueFrom`) | <pre>list(object(<br>    {<br>      name      = string<br>      valueFrom = string<br>    }<br>  ))</pre> | `[]` | no |
+| custom\_environment\_variables | List of additional environment variables the container will use (list should contain maps with `name` and `value`) | <pre>list(object(<br>    {<br>      name  = string<br>      value = string<br>    }<br>  ))</pre> | `[]` | no |
+| docker\_labels | The configuration options to send to the `docker_labels` | `map(string)` | `null` | no |
+| ecs\_container\_insights | Controls if ECS Cluster has container insights enabled | `bool` | `false` | no |
+| ecs\_service\_assign\_public\_ip | Should be true, if ECS service is using public subnets (more info: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_cannot_pull_image.html) | `bool` | `false` | no |
+| ecs\_service\_deployment\_maximum\_percent | The upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a service during a deployment | `number` | `200` | no |
+| ecs\_service\_deployment\_minimum\_healthy\_percent | The lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment | `number` | `50` | no |
+| ecs\_service\_desired\_count | The number of instances of the task definition to place and keep running | `number` | `1` | no |
+| ecs\_task\_cpu | The number of cpu units used by the task | `number` | `256` | no |
+| ecs\_task\_memory | The amount (in MiB) of memory used by the task | `number` | `512` | no |
+| entrypoint | The entry point that is passed to the container | `list(string)` | `null` | no |
+| essential | Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value | `bool` | `true` | no |
+| firelens\_configuration | The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html | <pre>object({<br>    type    = string<br>    options = map(string)<br>  })</pre> | `null` | no |
+| github\_webhooks\_cidr\_blocks | List of CIDR blocks used by GitHub webhooks | `list(string)` | <pre>[<br>  "140.82.112.0/20",<br>  "185.199.108.0/22",<br>  "192.30.252.0/22"<br>]</pre> | no |
+| internal | Whether the load balancer is internal or external | `bool` | `false` | no |
+| mount\_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume`. The `readOnly` key is optional. | `list` | `[]` | no |
+| name | Name to use on all resources created (VPC, ALB, etc) | `string` | `"atlantis"` | no |
+| policies\_arn | A list of the ARN of the policies you want to apply | `list(string)` | <pre>[<br>  "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"<br>]</pre> | no |
+| private\_subnet\_ids | A list of IDs of existing private subnets inside the VPC | `list(string)` | `[]` | no |
+| private\_subnets | A list of private subnets inside the VPC | `list(string)` | `[]` | no |
+| public\_subnet\_ids | A list of IDs of existing public subnets inside the VPC | `list(string)` | `[]` | no |
+| public\_subnets | A list of public subnets inside the VPC | `list(string)` | `[]` | no |
+| readonly\_root\_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value | `bool` | `false` | no |
+| repository\_credentials | Container repository credentials; required when using a private repo.  This map currently supports a single key; "credentialsParameter", which should be the ARN of a Secrets Manager's secret holding the credentials | `map(string)` | `null` | no |
+| route53\_record\_name | Name of Route53 record to create ACM certificate in and main A-record. If null is specified, var.name is used instead. Provide empty string to point root domain name to ALB. | `string` | `null` | no |
+| route53\_zone\_name | Route53 zone name to create ACM certificate in and main A-record, without trailing dot | `string` | `""` | no |
+| security\_group\_ids | List of one or more security groups to be added to the load balancer | `list(string)` | `[]` | no |
+| ssm\_kms\_key\_arn | ARN of KMS key to use for encryption and decryption of SSM Parameters. Required only if your key uses a custom KMS key and not the default key | `string` | `""` | no |
+| start\_timeout | Time duration (in seconds) to wait before giving up on resolving dependencies for a container | `number` | `30` | no |
+| stop\_timeout | Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own | `number` | `30` | no |
+| tags | A map of tags to use on all resources | `map(string)` | `{}` | no |
+| ulimits | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | <pre>list(object({<br>    name      = string<br>    hardLimit = number<br>    softLimit = number<br>  }))</pre> | `null` | no |
+| user | The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group. The default (null) will use the container's configured `USER` directive or root if not set. | `string` | `null` | no |
+| volumes\_from | A list of VolumesFrom maps which contain "sourceContainer" (name of the container that has the volumes to mount) and "readOnly" (whether the container can write to the volume) | <pre>list(object({<br>    sourceContainer = string<br>    readOnly        = bool<br>  }))</pre> | `[]` | no |
+| vpc\_id | ID of an existing VPC where resources will be created | `string` | `""` | no |
+| webhook\_ssm\_parameter\_name | Name of SSM parameter to keep webhook secret | `string` | `"/atlantis/webhook/secret"` | no |
+| whitelist\_unauthenticated\_cidr\_blocks | List of allowed CIDR blocks to bypass authentication | `list(string)` | `[]` | no |
+| working\_directory | The working directory to run commands inside the container | `string` | `null` | no |
 
 ## Outputs
 
@@ -253,7 +264,7 @@ allow_github_webhooks        = true
 | atlantis\_url | URL of Atlantis |
 | atlantis\_url\_events | Webhook events URL of Atlantis |
 | ecs\_security\_group | Security group assigned to ECS Service in network configuration |
-| ecs\_task\_definition | Task definition for ECS service \(used for external triggers\) |
+| ecs\_task\_definition | Task definition for ECS service (used for external triggers) |
 | task\_role\_arn | The Atlantis ECS task role arn |
 | vpc\_id | ID of the VPC that was created or passed in |
 | webhook\_secret | Webhook secret |

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ cd terraform-aws-atlantis
 ### Run Atlantis as a Terraform module
 
 This way allows integration with your existing Terraform configurations.
- 
+
 ```hcl
 module "atlantis" {
   source  = "terraform-aws-modules/atlantis/aws"
@@ -157,6 +157,7 @@ allow_github_webhooks        = true
 
 ## Examples
 
+* [Complete Atlantis with GitHub webhook](https://github.com/terraform-aws-modules/terraform-aws-atlantis/tree/master/examples/github-complete)
 * [GitHub repository webhook for Atlantis](https://github.com/terraform-aws-modules/terraform-aws-atlantis/tree/master/examples/github-repository-webhook)
 * [GitLab repository webhook for Atlantis](https://github.com/terraform-aws-modules/terraform-aws-atlantis/tree/master/examples/gitlab-repository-webhook)
 
@@ -265,7 +266,12 @@ No requirements.
 | atlantis\_url\_events | Webhook events URL of Atlantis |
 | ecs\_security\_group | Security group assigned to ECS Service in network configuration |
 | ecs\_task\_definition | Task definition for ECS service (used for external triggers) |
+| private\_subnet\_ids | IDs of the VPC private subnets that were created or passed in |
+| public\_subnet\_ids | IDs of the VPC public subnets that were created or passed in |
 | task\_role\_arn | The Atlantis ECS task role arn |
+| task\_role\_id | The Atlantis ECS task role id |
+| task\_role\_name | The Atlantis ECS task role name |
+| task\_role\_unique\_id | The stable and unique string identifying the Atlantis ECS task role. |
 | vpc\_id | ID of the VPC that was created or passed in |
 | webhook\_secret | Webhook secret |
 

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -1,0 +1,50 @@
+# Complete Atlantis example with GitHub Webhooks
+
+Configuration in this directory creates the necessary infrastructure and resources for running Atlantis on Fargate plus GitHub repository webhooks configured to Atlantis URL.
+
+An existing Route53 hosted zone and domain is required to deploy this example.
+
+GitHub's personal access token can be generated at https://github.com/settings/tokens
+
+## Usage
+
+To run this code you need to copy `terraform.tfvars.sample` into `terraform.tfvars` and update the values locally or specify them using environment variables (`TF_VAR_github_token=xxx`, `TF_VAR_github_organization=xxx`, etc.). Once ready, execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note - if you receive the following error when running apply:
+
+`Error: InvalidParameterException: The new ARN and resource ID format must be enabled to add tags to the service. Opt in to the new format and try again. "atlantiscomplete"`
+
+Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settings (update for your region of use) and change `Container instance`, `Service`, and `Task` to `Enabled`.
+
+⚠️ This example will create resources which cost money. Run `terraform destroy` when you don't need these resources. ⚠️
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| allowed\_repo\_names | Repositories that Atlantis will listen for events from and a webhook will be installed | list(string) | n/a | yes |
+| domain | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance | string | n/a | yes |
+| github\_organization | Github organization | string | n/a | yes |
+| github\_token | Github token | string | n/a | yes |
+| github\_user | Github user for Atlantis to utilize when performing Github activities | string | n/a | yes |
+| personal\_ip | Your current, personally ip to restrict access to Atlantis UI ending with `/32` for subnet | string | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| atlantis\_allowed\_repo\_names | Git repositories where webhook should be created |
+| atlantis\_url | URL of Atlantis |
+| ecs\_task\_definition | Task definition for ECS service \(used for external triggers\) |
+| github\_webhook\_secret | Github webhook secret |
+| github\_webhook\_urls | Github webhook URL |
+| task\_role\_arn | The Atlantis ECS task role arn |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -45,6 +45,7 @@ No requirements.
 | github\_token | Github token | `string` | n/a | yes |
 | github\_user | Github user for Atlantis to utilize when performing Github activities | `string` | n/a | yes |
 | personal\_ip | Your current, personally ip to restrict access to Atlantis UI ending with `/32` for subnet | `string` | n/a | yes |
+| region | AWS region where resources will be created | `string` | `"us-east-1"` | no |
 
 ## Outputs
 

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -25,16 +25,26 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 ⚠️ This example will create resources which cost money. Run `terraform destroy` when you don't need these resources. ⚠️
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| allowed\_repo\_names | Repositories that Atlantis will listen for events from and a webhook will be installed | list(string) | n/a | yes |
-| domain | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance | string | n/a | yes |
-| github\_organization | Github organization | string | n/a | yes |
-| github\_token | Github token | string | n/a | yes |
-| github\_user | Github user for Atlantis to utilize when performing Github activities | string | n/a | yes |
-| personal\_ip | Your current, personally ip to restrict access to Atlantis UI ending with `/32` for subnet | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| allowed\_repo\_names | Repositories that Atlantis will listen for events from and a webhook will be installed | `list(string)` | n/a | yes |
+| domain | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance | `string` | n/a | yes |
+| github\_organization | Github organization | `string` | n/a | yes |
+| github\_token | Github token | `string` | n/a | yes |
+| github\_user | Github user for Atlantis to utilize when performing Github activities | `string` | n/a | yes |
+| personal\_ip | Your current, personally ip to restrict access to Atlantis UI ending with `/32` for subnet | `string` | n/a | yes |
 
 ## Outputs
 
@@ -42,7 +52,7 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 |------|-------------|
 | atlantis\_allowed\_repo\_names | Git repositories where webhook should be created |
 | atlantis\_url | URL of Atlantis |
-| ecs\_task\_definition | Task definition for ECS service \(used for external triggers\) |
+| ecs\_task\_definition | Task definition for ECS service (used for external triggers) |
 | github\_webhook\_secret | Github webhook secret |
 | github\_webhook\_urls | Github webhook URL |
 | task\_role\_arn | The Atlantis ECS task role arn |

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -1,0 +1,211 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+locals {
+  tags = {
+    Owner       = "user"
+    Environment = "dev"
+  }
+}
+
+##############################################################
+# Data sources for existing resources
+##############################################################
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+##############################################################
+# Atlantis Service
+##############################################################
+
+module "atlantis" {
+  source = "../../"
+
+  name = "atlantiscomplete"
+
+  # VPC
+  cidr            = "10.20.0.0/16"
+  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  private_subnets = ["10.20.1.0/24", "10.20.2.0/24", "10.20.3.0/24"]
+  public_subnets  = ["10.20.101.0/24", "10.20.102.0/24", "10.20.103.0/24"]
+
+  # ECS
+  ecs_container_insights       = true
+  ecs_task_cpu                 = 512
+  ecs_task_memory              = 1024
+  container_memory_reservation = 256
+
+  entrypoint        = ["/bin/bash", "echo 'foo'", "docker-entrypoint.sh"]
+  command           = ["server"]
+  working_directory = "/tmp"
+  docker_labels = {
+    "org.opencontainers.image.title"       = "Atlantis"
+    "org.opencontainers.image.description" = "A self-hosted golang application that listens for Terraform pull request events via webhooks."
+    "org.opencontainers.image.url"         = "https://github.com/runatlantis/atlantis/blob/master/Dockerfile"
+  }
+  start_timeout = 30
+  stop_timeout  = 30
+
+  user                     = "atlantis"
+  readonly_root_filesystem = true
+  ulimits = [{
+    name      = "nofile"
+    softLimit = 4096
+    hardLimit = 16384
+  }]
+
+  # DNS
+  route53_zone_name = var.domain
+
+  # Atlantis
+  atlantis_github_user        = var.github_user
+  atlantis_github_user_token  = var.github_token
+  atlantis_repo_whitelist     = ["github.com/${var.github_organization}/*"]
+  atlantis_allowed_repo_names = var.allowed_repo_names
+
+  # ALB access
+  alb_ingress_cidr_blocks = [var.personal_ip]
+  alb_logging_enabled     = true
+  alb_log_bucket_name     = module.atlantis_access_log_bucket.this_s3_bucket_id
+  alb_log_location_prefix = "atlantis-alb"
+
+  allow_unauthenticated_access = true
+  allow_github_webhooks        = true
+  allow_repo_config            = true
+
+  tags = local.tags
+}
+
+################################################################################
+# GitHub Webhooks
+################################################################################
+
+module "github_repository_webhook" {
+  source = "../../modules/github-repository-webhook"
+
+  github_organization = var.github_organization
+  github_token        = var.github_token
+
+  atlantis_allowed_repo_names = module.atlantis.atlantis_allowed_repo_names
+
+  webhook_url    = module.atlantis.atlantis_url_events
+  webhook_secret = module.atlantis.webhook_secret
+}
+
+################################################################################
+# ALB Access Log Bucket + Policy
+################################################################################
+
+module "atlantis_access_log_bucket" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "~> 1.9"
+
+  bucket        = "${data.aws_caller_identity.current.account_id}-atlantis-access-logs-${data.aws_region.current.name}"
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.atlantis_access_log_bucket_policy.json
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  force_destroy = true
+
+  tags = local.tags
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  lifecycle_rule = [
+    {
+      id      = "all"
+      enabled = true
+
+      transition = [
+        {
+          days          = 30
+          storage_class = "ONEZONE_IA"
+          }, {
+          days          = 60
+          storage_class = "GLACIER"
+        }
+      ]
+
+      expiration = {
+        days = 90
+      }
+
+      noncurrent_version_expiration = {
+        days = 30
+      }
+    },
+  ]
+}
+
+data "aws_iam_policy_document" "atlantis_access_log_bucket_policy" {
+  statement {
+    sid     = "LogsLogDeliveryWrite"
+    effect  = "Allow"
+    actions = ["s3:PutObject"]
+    resources = [
+      "${module.atlantis_access_log_bucket.this_s3_bucket_arn}/*/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions
+        "arn:aws:iam::156460612806:root", # AWS logging eu-west-1 account id
+      ]
+    }
+  }
+
+  statement {
+    sid     = "AWSLogDeliveryWrite"
+    effect  = "Allow"
+    actions = ["s3:PutObject"]
+    resources = [
+      "${module.atlantis_access_log_bucket.this_s3_bucket_arn}/*/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "delivery.logs.amazonaws.com"
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+
+      values = [
+        "bucket-owner-full-control"
+      ]
+    }
+  }
+
+  statement {
+    sid     = "AWSLogDeliveryAclCheck"
+    effect  = "Allow"
+    actions = ["s3:GetBucketAcl"]
+    resources = [
+      module.atlantis_access_log_bucket.this_s3_bucket_arn
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "delivery.logs.amazonaws.com"
+      ]
+    }
+  }
+}

--- a/examples/github-complete/outputs.tf
+++ b/examples/github-complete/outputs.tf
@@ -1,0 +1,31 @@
+# Atlantis
+output "atlantis_url" {
+  description = "URL of Atlantis"
+  value       = module.atlantis.atlantis_url
+}
+
+output "atlantis_allowed_repo_names" {
+  description = "Git repositories where webhook should be created"
+  value       = module.atlantis.atlantis_allowed_repo_names
+}
+
+output "task_role_arn" {
+  description = "The Atlantis ECS task role arn"
+  value       = module.atlantis.task_role_arn
+}
+
+output "ecs_task_definition" {
+  description = "Task definition for ECS service (used for external triggers)"
+  value       = module.atlantis.ecs_task_definition
+}
+
+# Webhooks
+output "github_webhook_urls" {
+  description = "Github webhook URL"
+  value       = module.github_repository_webhook.this_repository_webhook_urls
+}
+
+output "github_webhook_secret" {
+  description = "Github webhook secret"
+  value       = module.github_repository_webhook.this_repository_webhook_secret
+}

--- a/examples/github-complete/terraform.tfvars.sample
+++ b/examples/github-complete/terraform.tfvars.sample
@@ -1,0 +1,6 @@
+domain = "mydomain.com"
+personal_ip = "69.100.100.100/32"
+github_organization = "myorg"
+github_user = "atlantis"
+github_token = "mygithubpersonalaccesstokenforatlantis"
+allowed_repo_names = ["repo1", "repo2"]

--- a/examples/github-complete/terraform.tfvars.sample
+++ b/examples/github-complete/terraform.tfvars.sample
@@ -1,5 +1,6 @@
+region = "eu-west-1
 domain = "mydomain.com"
-personal_ip = "69.100.100.100/32"
+personal_ip = "x.x.x.x/32"
 github_organization = "myorg"
 github_user = "atlantis"
 github_token = "mygithubpersonalaccesstokenforatlantis"

--- a/examples/github-complete/variables.tf
+++ b/examples/github-complete/variables.tf
@@ -1,3 +1,9 @@
+variable "region" {
+  description = "AWS region where resources will be created"
+  type        = string
+  default     = "us-east-1"
+}
+
 variable "domain" {
   description = "Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance"
   type        = string

--- a/examples/github-complete/variables.tf
+++ b/examples/github-complete/variables.tf
@@ -1,0 +1,29 @@
+variable "domain" {
+  description = "Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance"
+  type        = string
+}
+
+variable "personal_ip" {
+  description = "Your current, personally ip to restrict access to Atlantis UI ending with `/32` for subnet"
+  type        = string
+}
+
+variable "github_token" {
+  description = "Github token"
+  type        = string
+}
+
+variable "github_organization" {
+  description = "Github organization"
+  type        = string
+}
+
+variable "github_user" {
+  description = "Github user for Atlantis to utilize when performing Github activities"
+  type        = string
+}
+
+variable "allowed_repo_names" {
+  description = "Repositories that Atlantis will listen for events from and a webhook will be installed"
+  type        = list(string)
+}

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ locals {
   alb_authenication_method = length(keys(var.alb_authenticate_oidc)) > 0 ? "authenticate-oidc" : length(keys(var.alb_authenticate_cognito)) > 0 ? "authenticate-cognito" : "forward"
 
   # Container definitions
-  container_definitions = var.custom_container_definitions == "" ? var.atlantis_bitbucket_user_token != "" ? module.container_definition_bitbucket.json : module.container_definition_github_gitlab.json : var.custom_container_definitions
+  container_definitions = var.custom_container_definitions == "" ? var.atlantis_bitbucket_user_token != "" ? module.container_definition_bitbucket.json_map_encoded_list : module.container_definition_github_gitlab.json_map_encoded_list : var.custom_container_definitions
 
   container_definition_environment = [
     {

--- a/main.tf
+++ b/main.tf
@@ -161,7 +161,7 @@ resource "aws_ssm_parameter" "atlantis_bitbucket_user_token" {
 ###################
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "v2.33.0"
+  version = "v2.44.0"
 
   create_vpc = var.vpc_id == ""
 
@@ -260,7 +260,7 @@ resource "aws_lb_listener_rule" "unauthenticated_access_for_cidr_blocks" {
 ###################
 module "alb_https_sg" {
   source  = "terraform-aws-modules/security-group/aws//modules/https-443"
-  version = "v3.9.0"
+  version = "v3.13.0"
 
   name        = "${var.name}-alb-https"
   vpc_id      = local.vpc_id
@@ -273,7 +273,7 @@ module "alb_https_sg" {
 
 module "alb_http_sg" {
   source  = "terraform-aws-modules/security-group/aws//modules/http-80"
-  version = "v3.9.0"
+  version = "v3.13.0"
 
   name        = "${var.name}-alb-http"
   vpc_id      = local.vpc_id
@@ -286,7 +286,7 @@ module "alb_http_sg" {
 
 module "atlantis_sg" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "v3.9.0"
+  version = "v3.13.0"
 
   name        = var.name
   vpc_id      = local.vpc_id
@@ -312,7 +312,7 @@ module "atlantis_sg" {
 ###################
 module "acm" {
   source  = "terraform-aws-modules/acm/aws"
-  version = "v2.5.0"
+  version = "v2.9.0"
 
   create_certificate = var.certificate_arn == ""
 
@@ -345,9 +345,10 @@ resource "aws_route53_record" "atlantis" {
 ###################
 module "ecs" {
   source  = "terraform-aws-modules/ecs/aws"
-  version = "v2.0.0"
+  version = "v2.3.0"
 
-  name = var.name
+  name               = var.name
+  container_insights = var.ecs_container_insights
 
   tags = local.tags
 }
@@ -441,28 +442,20 @@ module "container_definition_github_gitlab" {
   container_memory             = var.ecs_task_memory
   container_memory_reservation = var.container_memory_reservation
 
-  entrypoint             = var.entrypoint
-  command                = var.command
-  working_directory      = var.working_directory
-  repository_credentials = var.repository_credentials
-  docker_labels          = var.docker_labels
-  start_timeout          = var.start_timeout
-  stop_timeout           = var.stop_timeout
-  container_depends_on   = var.container_depends_on
-
+  user                     = var.user
+  ulimits                  = var.ulimits
+  entrypoint               = var.entrypoint
+  command                  = var.command
+  working_directory        = var.working_directory
+  repository_credentials   = var.repository_credentials
+  docker_labels            = var.docker_labels
+  start_timeout            = var.start_timeout
+  stop_timeout             = var.stop_timeout
+  container_depends_on     = var.container_depends_on
   essential                = var.essential
   readonly_root_filesystem = var.readonly_root_filesystem
   mount_points             = var.mount_points
   volumes_from             = var.volumes_from
-  links                    = var.links
-
-  user            = var.user
-  privileged      = var.privileged
-  ulimits         = var.ulimits
-  system_controls = var.system_controls
-
-  dns_servers        = var.dns_servers
-  dns_search_domains = var.dns_search_domains
 
   port_mappings = [
     {
@@ -506,28 +499,20 @@ module "container_definition_bitbucket" {
   container_memory             = var.ecs_task_memory
   container_memory_reservation = var.container_memory_reservation
 
-  entrypoint             = var.entrypoint
-  command                = var.command
-  working_directory      = var.working_directory
-  repository_credentials = var.repository_credentials
-  docker_labels          = var.docker_labels
-  start_timeout          = var.start_timeout
-  stop_timeout           = var.stop_timeout
-  container_depends_on   = var.container_depends_on
-
+  user                     = var.user
+  ulimits                  = var.ulimits
+  entrypoint               = var.entrypoint
+  command                  = var.command
+  working_directory        = var.working_directory
+  repository_credentials   = var.repository_credentials
+  docker_labels            = var.docker_labels
+  start_timeout            = var.start_timeout
+  stop_timeout             = var.stop_timeout
+  container_depends_on     = var.container_depends_on
   essential                = var.essential
   readonly_root_filesystem = var.readonly_root_filesystem
   mount_points             = var.mount_points
   volumes_from             = var.volumes_from
-  links                    = var.links
-
-  user            = var.user
-  privileged      = var.privileged
-  ulimits         = var.ulimits
-  system_controls = var.system_controls
-
-  dns_servers        = var.dns_servers
-  dns_search_domains = var.dns_search_domains
 
   port_mappings = [
     {

--- a/main.tf
+++ b/main.tf
@@ -161,7 +161,7 @@ resource "aws_ssm_parameter" "atlantis_bitbucket_user_token" {
 ###################
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "v2.44.0"
+  version = "v2.47.0"
 
   create_vpc = var.vpc_id == ""
 
@@ -183,7 +183,7 @@ module "vpc" {
 ###################
 module "alb" {
   source  = "terraform-aws-modules/alb/aws"
-  version = "v5.6.0"
+  version = "v5.7.0"
 
   name     = var.name
   internal = var.internal
@@ -260,7 +260,7 @@ resource "aws_lb_listener_rule" "unauthenticated_access_for_cidr_blocks" {
 ###################
 module "alb_https_sg" {
   source  = "terraform-aws-modules/security-group/aws//modules/https-443"
-  version = "v3.13.0"
+  version = "v3.15.0"
 
   name        = "${var.name}-alb-https"
   vpc_id      = local.vpc_id
@@ -273,7 +273,7 @@ module "alb_https_sg" {
 
 module "alb_http_sg" {
   source  = "terraform-aws-modules/security-group/aws//modules/http-80"
-  version = "v3.13.0"
+  version = "v3.15.0"
 
   name        = "${var.name}-alb-http"
   vpc_id      = local.vpc_id
@@ -286,7 +286,7 @@ module "alb_http_sg" {
 
 module "atlantis_sg" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "v3.13.0"
+  version = "v3.15.0"
 
   name        = var.name
   vpc_id      = local.vpc_id
@@ -312,7 +312,7 @@ module "atlantis_sg" {
 ###################
 module "acm" {
   source  = "terraform-aws-modules/acm/aws"
-  version = "v2.9.0"
+  version = "v2.10.0"
 
   create_certificate = var.certificate_arn == ""
 
@@ -433,7 +433,7 @@ resource "aws_iam_role_policy" "ecs_task_access_secrets" {
 
 module "container_definition_github_gitlab" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "v0.37.0"
+  version = "v0.40.0"
 
   container_name  = var.name
   container_image = local.atlantis_image
@@ -490,7 +490,7 @@ module "container_definition_github_gitlab" {
 
 module "container_definition_bitbucket" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "v0.37.0"
+  version = "v0.40.0"
 
   container_name  = var.name
   container_image = local.atlantis_image

--- a/main.tf
+++ b/main.tf
@@ -266,7 +266,7 @@ module "alb_https_sg" {
   vpc_id      = local.vpc_id
   description = "Security group with HTTPS ports open for specific IPv4 CIDR block (or everybody), egress ports are all world open"
 
-  ingress_cidr_blocks = var.alb_ingress_cidr_blocks
+  ingress_cidr_blocks = sort(compact(concat(var.allow_github_webhooks ? var.github_webhooks_cidr_blocks : [], var.alb_ingress_cidr_blocks)))
 
   tags = local.tags
 }
@@ -279,7 +279,7 @@ module "alb_http_sg" {
   vpc_id      = local.vpc_id
   description = "Security group with HTTP ports open for specific IPv4 CIDR block (or everybody), egress ports are all world open"
 
-  ingress_cidr_blocks = var.alb_ingress_cidr_blocks
+  ingress_cidr_blocks = sort(compact(concat(var.allow_github_webhooks ? var.github_webhooks_cidr_blocks : [], var.alb_ingress_cidr_blocks)))
 
   tags = local.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -432,7 +432,7 @@ resource "aws_iam_role_policy" "ecs_task_access_secrets" {
 
 module "container_definition_github_gitlab" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "v0.23.0"
+  version = "v0.37.0"
 
   container_name  = var.name
   container_image = local.atlantis_image
@@ -440,6 +440,29 @@ module "container_definition_github_gitlab" {
   container_cpu                = var.ecs_task_cpu
   container_memory             = var.ecs_task_memory
   container_memory_reservation = var.container_memory_reservation
+
+  entrypoint             = var.entrypoint
+  command                = var.command
+  working_directory      = var.working_directory
+  repository_credentials = var.repository_credentials
+  docker_labels          = var.docker_labels
+  start_timeout          = var.start_timeout
+  stop_timeout           = var.stop_timeout
+  container_depends_on   = var.container_depends_on
+
+  essential                = var.essential
+  readonly_root_filesystem = var.readonly_root_filesystem
+  mount_points             = var.mount_points
+  volumes_from             = var.volumes_from
+  links                    = var.links
+
+  user            = var.user
+  privileged      = var.privileged
+  ulimits         = var.ulimits
+  system_controls = var.system_controls
+
+  dns_servers        = var.dns_servers
+  dns_search_domains = var.dns_search_domains
 
   port_mappings = [
     {
@@ -458,6 +481,7 @@ module "container_definition_github_gitlab" {
     }
     secretOptions = []
   }
+  firelens_configuration = var.firelens_configuration
 
   environment = concat(
     local.container_definition_environment,
@@ -473,7 +497,7 @@ module "container_definition_github_gitlab" {
 
 module "container_definition_bitbucket" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "v0.23.0"
+  version = "v0.37.0"
 
   container_name  = var.name
   container_image = local.atlantis_image
@@ -481,6 +505,29 @@ module "container_definition_bitbucket" {
   container_cpu                = var.ecs_task_cpu
   container_memory             = var.ecs_task_memory
   container_memory_reservation = var.container_memory_reservation
+
+  entrypoint             = var.entrypoint
+  command                = var.command
+  working_directory      = var.working_directory
+  repository_credentials = var.repository_credentials
+  docker_labels          = var.docker_labels
+  start_timeout          = var.start_timeout
+  stop_timeout           = var.stop_timeout
+  container_depends_on   = var.container_depends_on
+
+  essential                = var.essential
+  readonly_root_filesystem = var.readonly_root_filesystem
+  mount_points             = var.mount_points
+  volumes_from             = var.volumes_from
+  links                    = var.links
+
+  user            = var.user
+  privileged      = var.privileged
+  ulimits         = var.ulimits
+  system_controls = var.system_controls
+
+  dns_servers        = var.dns_servers
+  dns_search_domains = var.dns_search_domains
 
   port_mappings = [
     {
@@ -499,6 +546,7 @@ module "container_definition_bitbucket" {
     }
     secretOptions = []
   }
+  firelens_configuration = var.firelens_configuration
 
   environment = concat(
     local.container_definition_environment,

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,4 @@
+# Atlantis
 output "atlantis_url" {
   description = "URL of Atlantis"
   value       = local.atlantis_url
@@ -13,29 +14,30 @@ output "atlantis_allowed_repo_names" {
   value       = var.atlantis_allowed_repo_names
 }
 
-output "task_role_arn" {
-  description = "The Atlantis ECS task role arn"
-  value       = aws_iam_role.ecs_task_execution.arn
-}
-
-output "vpc_id" {
-  description = "ID of the VPC that was created or passed in"
-  value       = local.vpc_id
-}
-
 output "webhook_secret" {
   description = "Webhook secret"
   value       = element(concat(random_id.webhook.*.hex, [""]), 0)
 }
 
-output "alb_dns_name" {
-  description = "Dns name of alb"
-  value       = module.alb.this_lb_dns_name
+# ECS
+output "task_role_arn" {
+  description = "The Atlantis ECS task role arn"
+  value       = aws_iam_role.ecs_task_execution.arn
 }
 
-output "alb_zone_id" {
-  description = "Zone ID of alb"
-  value       = module.alb.this_lb_zone_id
+output "task_role_id" {
+  description = "The Atlantis ECS task role id"
+  value       = aws_iam_role.ecs_task_execution.id
+}
+
+output "task_role_name" {
+  description = "The Atlantis ECS task role name"
+  value       = aws_iam_role.ecs_task_execution.name
+}
+
+output "task_role_unique_id" {
+  description = "The stable and unique string identifying the Atlantis ECS task role."
+  value       = aws_iam_role.ecs_task_execution.unique_id
 }
 
 output "ecs_task_definition" {
@@ -46,4 +48,31 @@ output "ecs_task_definition" {
 output "ecs_security_group" {
   description = "Security group assigned to ECS Service in network configuration"
   value       = module.atlantis_sg.this_security_group_id
+}
+
+# VPC
+output "vpc_id" {
+  description = "ID of the VPC that was created or passed in"
+  value       = local.vpc_id
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the VPC private subnets that were created or passed in"
+  value       = local.private_subnet_ids
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the VPC public subnets that were created or passed in"
+  value       = local.public_subnet_ids
+}
+
+# ALB
+output "alb_dns_name" {
+  description = "Dns name of alb"
+  value       = module.alb.this_lb_dns_name
+}
+
+output "alb_zone_id" {
+  description = "Zone ID of alb"
+  value       = module.alb.this_lb_zone_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -215,6 +215,12 @@ variable "policies_arn" {
   default     = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
 }
 
+variable "ecs_container_insights" {
+  description = "Controls if ECS Cluster has container insights enabled"
+  type        = bool
+  default     = false
+}
+
 variable "ecs_service_desired_count" {
   description = "The number of instances of the task definition to place and keep running"
   type        = number
@@ -336,21 +342,9 @@ variable "volumes_from" {
   default = []
 }
 
-variable "links" {
-  description = "List of container names this container can communicate with without port mappings"
-  type        = list(string)
-  default     = null
-}
-
 variable "user" {
   description = "The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group. The default (null) will use the container's configured `USER` directive or root if not set."
   type        = string
-  default     = null
-}
-
-variable "privileged" {
-  description = "When this variable is `true`, the container is given elevated privileges on the host container instance (similar to the root user). This parameter is not supported for Windows containers or tasks using the Fargate launch type."
-  type        = bool
   default     = null
 }
 
@@ -362,24 +356,6 @@ variable "ulimits" {
     softLimit = number
   }))
   default = null
-}
-
-variable "system_controls" {
-  description = "A list of namespaced kernel parameters to set in the container, mapping to the --sysctl option to docker run. This is a list of maps: { namespace = \"\", value = \"\"}"
-  type        = list(map(string))
-  default     = null
-}
-
-variable "dns_servers" {
-  description = "Container DNS servers. This is a list of strings specifying the IP addresses of the DNS servers"
-  type        = list(string)
-  default     = null
-}
-
-variable "dns_search_domains" {
-  description = "Container DNS search domains. A list of DNS search domains that are presented to the container"
-  type        = list(string)
-  default     = null
 }
 
 # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html

--- a/variables.tf
+++ b/variables.tf
@@ -257,6 +257,141 @@ variable "custom_container_definitions" {
   default     = ""
 }
 
+variable "entrypoint" {
+  description = "The entry point that is passed to the container"
+  type        = list(string)
+  default     = null
+}
+
+variable "command" {
+  description = "The command that is passed to the container"
+  type        = list(string)
+  default     = null
+}
+
+variable "working_directory" {
+  description = "The working directory to run commands inside the container"
+  type        = string
+  default     = null
+}
+
+variable "repository_credentials" {
+  description = "Container repository credentials; required when using a private repo.  This map currently supports a single key; \"credentialsParameter\", which should be the ARN of a Secrets Manager's secret holding the credentials"
+  type        = map(string)
+  default     = null
+}
+
+
+variable "docker_labels" {
+  description = "The configuration options to send to the `docker_labels`"
+  type        = map(string)
+  default     = null
+}
+
+variable "start_timeout" {
+  description = "Time duration (in seconds) to wait before giving up on resolving dependencies for a container"
+  type        = number
+  default     = 30
+}
+
+variable "stop_timeout" {
+  description = "Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own"
+  type        = number
+  default     = 30
+}
+
+variable "container_depends_on" {
+  description = "The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed. The condition can be one of START, COMPLETE, SUCCESS or HEALTHY"
+  type = list(object({
+    containerName = string
+    condition     = string
+  }))
+  default = null
+}
+
+variable "essential" {
+  description = "Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value"
+  type        = bool
+  default     = true
+}
+
+variable "readonly_root_filesystem" {
+  description = "Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value"
+  type        = bool
+  default     = false
+}
+
+variable "mount_points" {
+  description = "Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume`. The `readOnly` key is optional."
+  type        = list
+  default     = []
+}
+
+variable "volumes_from" {
+  description = "A list of VolumesFrom maps which contain \"sourceContainer\" (name of the container that has the volumes to mount) and \"readOnly\" (whether the container can write to the volume)"
+  type = list(object({
+    sourceContainer = string
+    readOnly        = bool
+  }))
+  default = []
+}
+
+variable "links" {
+  description = "List of container names this container can communicate with without port mappings"
+  type        = list(string)
+  default     = null
+}
+
+variable "user" {
+  description = "The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group. The default (null) will use the container's configured `USER` directive or root if not set."
+  type        = string
+  default     = null
+}
+
+variable "privileged" {
+  description = "When this variable is `true`, the container is given elevated privileges on the host container instance (similar to the root user). This parameter is not supported for Windows containers or tasks using the Fargate launch type."
+  type        = bool
+  default     = null
+}
+
+variable "ulimits" {
+  description = "Container ulimit settings. This is a list of maps, where each map should contain \"name\", \"hardLimit\" and \"softLimit\""
+  type = list(object({
+    name      = string
+    hardLimit = number
+    softLimit = number
+  }))
+  default = null
+}
+
+variable "system_controls" {
+  description = "A list of namespaced kernel parameters to set in the container, mapping to the --sysctl option to docker run. This is a list of maps: { namespace = \"\", value = \"\"}"
+  type        = list(map(string))
+  default     = null
+}
+
+variable "dns_servers" {
+  description = "Container DNS servers. This is a list of strings specifying the IP addresses of the DNS servers"
+  type        = list(string)
+  default     = null
+}
+
+variable "dns_search_domains" {
+  description = "Container DNS search domains. A list of DNS search domains that are presented to the container"
+  type        = list(string)
+  default     = null
+}
+
+# https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html
+variable "firelens_configuration" {
+  description = "The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html"
+  type = object({
+    type    = string
+    options = map(string)
+  })
+  default = null
+}
+
 # Atlantis
 variable "atlantis_image" {
   description = "Docker image to run Atlantis with. If not specified, official Atlantis image will be used"

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 0.12.7, < 0.14"
+
+  required_providers {
+    aws = ">= 2.68, < 4.0"
+  }
+}


### PR DESCRIPTION
## Description
- Update module dependencies to latest; this is a no-op change when tested
- Update container definition to include additional parameters that are available by the module for those that are relevant to Fargate (allows for more configuration and flexibility)
- Add complete example with GitHub webhooks for testing as well as demonstrating module usage
- Update pre-commit to latest and remove validate (requires `terraform init` to be run prior on all workspaces/root directories)
- Update modules to support AWS provider 3.x and Terraform 0.13.x

## Motivation and Context
- Primary motivation was to update the ECS container definition sub-module  to allow for more flexibility and configuration as that module as advanced and evolved. This update exposes configurations for running containers/tasks more securely as well as taking advantage of the latest feature improvements to Fargate
- Closes #143 and #71 - supersedes #131, #103, and #91

## Breaking Changes
- None at this time

## How Has This Been Tested?
1. I have an existing Atlantis module running in production on v2.20.0. Updating the source to point to this change request showed no updates to be made
2. There is now an example for testing/validation under `examples/github-complete` which includes both the Atlantis resources (including VPC and access logging bucket) as well as GitHub webhooks which also validated the changes when run anew
