### PR TITLE
feat: add variable to set SSL listener policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ allow_github_webhooks        = true
 | alb\_authenticate\_cognito | Map of AWS Cognito authentication parameters to protect ALB (eg, using SAML). See https://www.terraform.io/docs/providers/aws/r/lb_listener.html#authenticate-cognito-action | `any` | `{}` | no |
 | alb\_authenticate\_oidc | Map of Authenticate OIDC parameters to protect ALB (eg, using Auth0). See https://www.terraform.io/docs/providers/aws/r/lb_listener.html#authenticate-oidc-action | `any` | `{}` | no |
 | alb\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules of the ALB. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| alb\_listener\_ssl\_policy\_default | The security policy if using HTTPS externally on the load balancer. [See](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html). | `string` | `"ELBSecurityPolicy-2016-08"` | no |
 | alb\_log\_bucket\_name | S3 bucket (externally created) for storing load balancer access logs. Required if alb\_logging\_enabled is true. | `string` | `""` | no |
 | alb\_log\_location\_prefix | S3 prefix within the log\_bucket\_name under which logs are stored. | `string` | `""` | no |
 | alb\_logging\_enabled | Controls if the ALB will log requests to S3. | `bool` | `false` | no |

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -39,12 +39,12 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| alb\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules of the ALB - use your personal IP in the form of `x.x.x.x/32` for restricted testing | `string` | n/a | yes |
 | allowed\_repo\_names | Repositories that Atlantis will listen for events from and a webhook will be installed | `list(string)` | n/a | yes |
 | domain | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance | `string` | n/a | yes |
 | github\_organization | Github organization | `string` | n/a | yes |
 | github\_token | Github token | `string` | n/a | yes |
 | github\_user | Github user for Atlantis to utilize when performing Github activities | `string` | n/a | yes |
-| personal\_ip | Your current, personally ip to restrict access to Atlantis UI ending with `/32` for subnet | `string` | n/a | yes |
 | region | AWS region where resources will be created | `string` | `"us-east-1"` | no |
 
 ## Outputs

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -69,7 +69,7 @@ module "atlantis" {
   atlantis_allowed_repo_names = var.allowed_repo_names
 
   # ALB access
-  alb_ingress_cidr_blocks         = [var.personal_ip]
+  alb_ingress_cidr_blocks         = [var.alb_ingress_cidr_blocks]
   alb_logging_enabled             = true
   alb_log_bucket_name             = module.atlantis_access_log_bucket.this_s3_bucket_id
   alb_log_location_prefix         = "atlantis-alb"

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -69,10 +69,11 @@ module "atlantis" {
   atlantis_allowed_repo_names = var.allowed_repo_names
 
   # ALB access
-  alb_ingress_cidr_blocks = [var.personal_ip]
-  alb_logging_enabled     = true
-  alb_log_bucket_name     = module.atlantis_access_log_bucket.this_s3_bucket_id
-  alb_log_location_prefix = "atlantis-alb"
+  alb_ingress_cidr_blocks         = [var.personal_ip]
+  alb_logging_enabled             = true
+  alb_log_bucket_name             = module.atlantis_access_log_bucket.this_s3_bucket_id
+  alb_log_location_prefix         = "atlantis-alb"
+  alb_listener_ssl_policy_default = "ELBSecurityPolicy-TLS-1-2-2017-01"
 
   allow_unauthenticated_access = true
   allow_github_webhooks        = true

--- a/examples/github-complete/variables.tf
+++ b/examples/github-complete/variables.tf
@@ -9,8 +9,8 @@ variable "domain" {
   type        = string
 }
 
-variable "personal_ip" {
-  description = "Your current, personally ip to restrict access to Atlantis UI ending with `/32` for subnet"
+variable "alb_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all ingress rules of the ALB - use your personal IP in the form of `x.x.x.x/32` for restricted testing"
   type        = string
 }
 

--- a/main.tf
+++ b/main.tf
@@ -198,6 +198,7 @@ module "alb" {
     prefix  = var.alb_log_location_prefix
   }
 
+  listener_ssl_policy_default = var.alb_listener_ssl_policy_default
   https_listeners = [
     {
       target_group_index   = 0

--- a/variables.tf
+++ b/variables.tf
@@ -132,6 +132,12 @@ variable "whitelist_unauthenticated_cidr_blocks" {
   default     = []
 }
 
+variable "alb_listener_ssl_policy_default" {
+  description = "The security policy if using HTTPS externally on the load balancer. [See](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html)."
+  type        = string
+  default     = "ELBSecurityPolicy-2016-08"
+}
+
 # ACM
 variable "certificate_arn" {
   description = "ARN of certificate issued by AWS ACM. If empty, a new ACM certificate will be created and validated using Route53 DNS"


### PR DESCRIPTION
## Description
- add variable to allow changing SSL listener policy on HTTPS listener; currently set to current modules default so no changes to current module users

## Motivation and Context
- to be able to use a stronger cipher suite on the ALB that is created

## Breaking Changes
none

## How Has This Been Tested?
- complete example was updated and validated deployment
