### PR TITLE
feat: Capability to add more trusted principals to task role

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ allow_github_webhooks        = true
 | start\_timeout | Time duration (in seconds) to wait before giving up on resolving dependencies for a container | `number` | `30` | no |
 | stop\_timeout | Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own | `number` | `30` | no |
 | tags | A map of tags to use on all resources | `map(string)` | `{}` | no |
+| trusted\_principals | A list of principals, in addition to ecs-tasks.amazonaws.com, that can assume the task role | `list(string)` | <pre>[]</pre> | no |
 | ulimits | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | <pre>list(object({<br>    name      = string<br>    hardLimit = number<br>    softLimit = number<br>  }))</pre> | `null` | no |
 | user | The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group. The default (null) will use the container's configured `USER` directive or root if not set. | `string` | `null` | no |
 | volumes\_from | A list of VolumesFrom maps which contain "sourceContainer" (name of the container that has the volumes to mount) and "readOnly" (whether the container can write to the volume) | <pre>list(object({<br>    sourceContainer = string<br>    readOnly        = bool<br>  }))</pre> | `[]` | no |

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -46,6 +46,7 @@ No requirements.
 | github\_token | Github token | `string` | n/a | yes |
 | github\_user | Github user for Atlantis to utilize when performing Github activities | `string` | n/a | yes |
 | region | AWS region where resources will be created | `string` | `"us-east-1"` | no |
+| trusted\_principals | A list of principals, in addition to ecs-tasks.amazonaws.com, that can assume the task role | | `list(string)` | n/a | no |
 
 ## Outputs
 

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -59,6 +59,9 @@ module "atlantis" {
     hardLimit = 16384
   }]
 
+  # Security
+  trusted_principals = ["ssm.amazonaws.com"] # Convenient if you want to enable SSM access into Atlantis for troubleshooting etc
+
   # DNS
   route53_zone_name = var.domain
 

--- a/examples/github-complete/terraform.tfvars.sample
+++ b/examples/github-complete/terraform.tfvars.sample
@@ -5,3 +5,4 @@ github_organization = "myorg"
 github_user = "atlantis"
 github_token = "mygithubpersonalaccesstokenforatlantis"
 allowed_repo_names = ["repo1", "repo2"]
+trusted_principals = ["xyz.amazonaws.com"]

--- a/examples/github-complete/variables.tf
+++ b/examples/github-complete/variables.tf
@@ -33,3 +33,8 @@ variable "allowed_repo_names" {
   description = "Repositories that Atlantis will listen for events from and a webhook will be installed"
   type        = list(string)
 }
+
+variable "trusted_principals" {
+  description = "A list of principals, in addition to ecs-tasks.amazonaws.com, that can assume the task role"
+  type        = list(string)
+}

--- a/main.tf
+++ b/main.tf
@@ -364,7 +364,7 @@ data "aws_iam_policy_document" "ecs_tasks" {
 
     principals {
       type        = "Service"
-      identifiers = ["ecs-tasks.amazonaws.com"]
+      identifiers = concat(["ecs-tasks.amazonaws.com"], var.trusted_principals)
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -239,6 +239,12 @@ variable "policies_arn" {
   default     = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
 }
 
+variable "trusted_principals" {
+  description = "A list of principals, in addition to ecs-tasks.amazonaws.com, that can assume the task role"
+  type        = list(string)
+  default     = []
+}
+
 variable "ecs_container_insights" {
   description = "Controls if ECS Cluster has container insights enabled"
   type        = bool


### PR DESCRIPTION

## Description
Extra input variable to allow module users to optionally define extra principals that can assume the task role.
Apart from the main module code and documentation, the example is also updated to showcase how the new variable can be used.

## Motivation and Context
At the moment, the only trusted entity to assume the task role is the absolute minimum `ecs-tasks.amazonaws.com`.
However sometimes it's convenient to allow adding more principals.
For example in order to allow easy SSM access into the Fargate task, `ssm.amazonaws.com` should be trusted too.

## Breaking Changes
No breaking changes. Just adding an optional input variable.

## How Has This Been Tested?
From my project downstream, I have referenced this PR branch and applied my infrastructure. It works as expected.
