### PR TITLE
feat: adding the ATLANTIS_ALLOW_FORK_PRS environment variable to the Atlantis ECS task

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ allow_github_webhooks        = true
 | allow\_repo\_config | When true allows the use of atlantis.yaml config files within the source repos. | `string` | `"false"` | no |
 | allow\_unauthenticated\_access | Whether to create ALB listener rule to allow unauthenticated access for certain CIDR blocks (eg. allow GitHub webhooks to bypass OIDC authentication) | `bool` | `false` | no |
 | allow\_unauthenticated\_access\_priority | ALB listener rule priority for allow unauthenticated access rule | `number` | `10` | no |
+| atlantis\_allow\_fork\_prs | Respond to pull requests from forks. Defaults to `"false"`. | `string` | `"false"` | no |
 | atlantis\_allowed\_repo\_names | Git repositories where webhook should be created | `list(string)` | `[]` | no |
 | atlantis\_bitbucket\_base\_url | Base URL of Bitbucket Server, use for Bitbucket on prem (Stash) | `string` | `""` | no |
 | atlantis\_bitbucket\_user | Bitbucket username that is running the Atlantis command | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -75,6 +75,10 @@ locals {
       name  = "ATLANTIS_HIDE_PREV_PLAN_COMMENTS"
       value = var.atlantis_hide_prev_plan_comments
     },
+    {
+      name  = "ATLANTIS_ALLOW_FORK_PRS"
+      value = var.atlantis_allow_fork_prs
+    },
   ]
 
   # Secret access tokens

--- a/variables.tf
+++ b/variables.tf
@@ -523,3 +523,9 @@ variable "security_group_ids" {
   type        = list(string)
   default     = []
 }
+
+variable "atlantis_allow_fork_prs" {
+  description = "Respond to pull requests from forks. Defaults to `false`."
+  type        = string
+  default     = "false"
+}


### PR DESCRIPTION
## Description
Closes #156.

The change allows the --allow-fork-prs to be set via the ATLANTIS_ALLOW_FORK_PRS environment variable.

## Motivation and Context
Motivation and context can be read in https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/156

## Breaking Changes
No breaking changes, a `terraform plan` will yield a new ECS task version though due to the new environment variable.

## How Has This Been Tested?
I have used the module as I have used the module as `source = "git::git@github.com:Szasza/terraform-aws-atlantis.git?ref=master` and ran `terraform plan` and `terraform apply`. The changes in the ECS task definition showed up correctly and the environment variable's value defaulted to `false` to ensure backward compatibility.