### PR TITLE
feat: enable configuring of atlantis server --checkout-strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ allow_github_webhooks        = true
 | atlantis\_bitbucket\_user | Bitbucket username that is running the Atlantis command | `string` | `""` | no |
 | atlantis\_bitbucket\_user\_token | Bitbucket token of the user that is running the Atlantis command | `string` | `""` | no |
 | atlantis\_bitbucket\_user\_token\_ssm\_parameter\_name | Name of SSM parameter to keep atlantis\_bitbucket\_user\_token | `string` | `"/atlantis/bitbucket/user/token"` | no |
+| atlantis\_checkout\_strategy | Configure atlantis server --checkout-strategy 'merge' or 'branch' | `string` | `"branch"` | no
 | atlantis\_fqdn | FQDN of Atlantis to use. Set this only to override Route53 and ALB's DNS name. | `string` | `null` | no |
 | atlantis\_github\_user | GitHub username that is running the Atlantis command | `string` | `""` | no |
 | atlantis\_github\_user\_token | GitHub token of the user that is running the Atlantis command | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -75,6 +75,10 @@ locals {
       name  = "ATLANTIS_HIDE_PREV_PLAN_COMMENTS"
       value = var.atlantis_hide_prev_plan_comments
     },
+    {
+      name  = "ATLANTIS_CHECKOUT_STRATEGY"
+      value = var.atlantis_checkout_strategy
+    },
   ]
 
   # Secret access tokens

--- a/variables.tf
+++ b/variables.tf
@@ -433,6 +433,21 @@ variable "atlantis_log_level" {
   default     = "debug"
 }
 
+variable "atlantis_checkout_strategy" {
+  description = """
+    Configure atlantis server --checkout-strategy
+
+    How to check out pull requests. Accepts either 'branch' (default) or 'merge'.
+    If set to branch, Atlantis will check out the source branch of the pull request.
+    If set to merge, Atlantis will check out the destination branch of the pull request (ex. master)
+    and then locally perform a git merge of the source branch.
+    This effectively means Atlantis operates on the repo as it will look
+    after the pull request is merged.
+  """
+  type = string
+  default = "branch"
+}
+
 variable "atlantis_hide_prev_plan_comments" {
   description = "Enables atlantis server --hide-prev-plan-comments hiding previous plan comments on update"
   type        = string


### PR DESCRIPTION
## Description

Enable configuring `--checkout-strategy` Implemented in this atlantis pr https://github.com/runatlantis/atlantis/pull/427/files

```
		description: "How to check out pull requests. Accepts either 'branch' (default) or 'merge'." +
			" If set to branch, Atlantis will check out the source branch of the pull request." +
			" If set to merge, Atlantis will check out the destination branch of the pull request (ex. master)" +
			" and then locally perform a git merge of the source branch." +
			" This effectively means Atlantis operates on the repo as it will look" +
			" after the pull request is merged.",
```

## Motivation and Context

Atm an atlantis instance deployed via this module cannot configure this setting.  Meaning that all deployments from atlantis from this module will take the default `branch` option for this flag on `atlantis server`.

According to the docs, that will only check out the branch we wish to apply.  This can cause problems if someone made a branch prior to an important master change, then atlantis applies removing that last change (if the user never rebased master)

We would like to be able to try to use this flag on our atlantis instance.

## Breaking Changes

There are no breaking changes here, the variable that is introduced `atlantis_checkout_strategy` defaults to `branch` which is what the flag already defaults to `branch`, you can see in their pr or on latest master https://github.com/runatlantis/atlantis/blob/master/cmd/server.go#L157

## How Has This Been Tested?

These create environment vars in the same methodology this repo currently uses and these env vars are passed via viper.AutomaticEnv, they are also checked for in their tests on that pr 

https://github.com/runatlantis/atlantis/pull/427/files#diff-3b1c14f936e65b2202c014583477ef8d2a67f69d9946a6b4e6829dee5486d0c9R595
