### PR TITLE
feat: allow for extra_container_definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ allow_github_webhooks        = true
 | ecs\_task\_memory | The amount (in MiB) of memory used by the task | `number` | `512` | no |
 | entrypoint | The entry point that is passed to the container | `list(string)` | `null` | no |
 | essential | Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value | `bool` | `true` | no |
+| extra\_container\_definitions | A list of valid container definitions provided as a single valid JSON document. These will be provided as supplimentary to the main Atlantis container definition | `list(any)` | `[]` | no |
 | firelens\_configuration | The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html | <pre>object({<br>    type    = string<br>    options = map(string)<br>  })</pre> | `null` | no |
 | github\_webhooks\_cidr\_blocks | List of CIDR blocks used by GitHub webhooks | `list(string)` | <pre>[<br>  "140.82.112.0/20",<br>  "185.199.108.0/22",<br>  "192.30.252.0/22"<br>]</pre> | no |
 | internal | Whether the load balancer is internal or external | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ locals {
   alb_authenication_method = length(keys(var.alb_authenticate_oidc)) > 0 ? "authenticate-oidc" : length(keys(var.alb_authenticate_cognito)) > 0 ? "authenticate-cognito" : "forward"
 
   # Container definitions
-  container_definitions = var.custom_container_definitions == "" ? var.atlantis_bitbucket_user_token != "" ? module.container_definition_bitbucket.json_map_encoded_list : module.container_definition_github_gitlab.json_map_encoded_list : var.custom_container_definitions
+  container_definitions = var.custom_container_definitions == "" ? var.atlantis_bitbucket_user_token != "" ? jsonencode(concat([module.container_definition_bitbucket.json_map_object], var.extra_container_definitions)) : jsonencode(concat([module.container_definition_github_gitlab.json_map_object], var.extra_container_definitions)) : var.custom_container_definitions
 
   container_definition_environment = [
     {

--- a/variables.tf
+++ b/variables.tf
@@ -293,6 +293,12 @@ variable "custom_container_definitions" {
   default     = ""
 }
 
+variable "extra_container_definitions" {
+  description = "A list of valid container definitions provided as a single valid JSON document. These will be provided as supplimentary to the main Atlantis container definition"
+  type        = list(any)
+  default     = []
+}
+
 variable "entrypoint" {
   description = "The entry point that is passed to the container"
   type        = list(string)


### PR DESCRIPTION
## Description
This expands the options by allowing users to add supplimentary container definitions in addition to the existing replacement of all container definitions.

The current limit is `var.ecs_task_cpu` is used for both the atlantis container definition and the task definition which means there's no room for any additional container definitions to use CPU. This is okay for me, as my sidecar exits 0 after writing files to the shared volume, but I may add a `var.ecs_container_cpu` which will default to `ecs_task_cpu` if it's not set, but will allow an author to expand the task CPU limits and the container limits independently. 

## Motivation and Context
This allows me, in particular, to provide additional sidecars while still using the recommended container definitions. It primarily addresses #133 

## Breaking Changes
This is a supplementary change and should not break compatibility 

## How Has This Been Tested?
This has been tested today using a very similar template below:

```hcl
module "container_definition_atlantis_sidecar" {
  source  = "cloudposse/ecs-container-definition/aws"
  version = "v0.40.0"

  container_name  = "atlantis_sidecar"
  container_image = data.aws_ecr_repository.atlantis_sidecar.repository_url

  container_cpu                = 0
  container_memory             = 64
  container_memory_reservation = 64

  readonly_root_filesystem = true

  essential = false

  secrets = [
    {
      name = "scrubed",
      valueFrom = data.aws_secretsmanager_secret.scrubed.arn,
    }
  ]
}

module "atlantis" {
  source = "github.com/stacklet/terraform-aws-atlantis?ref=issue-133"

  name = "atlantis"

  cidr            = "x.x.x.x/x"
  azs             = ["us-east-2a", "us-east-2b", "us-east-2c"]
  private_subnets = ["x.x.x.x/x", "x.x.x.x/x", "x.x.x.x/x"]
  public_subnets  = ["x.x.x.x/x", "x.x.x.x/x", "x.x.x.x/x"]

  route53_zone_name = "xxx.yyy"

  atlantis_github_user           = "marcoceppi"
  atlantis_github_user_token     = data.aws_kms_secrets.atlantis.plaintext["github_user_token"]

  extra_container_definitions = [module.container_definition_atlantis_sidecar.json_map_object]

  allow_unauthenticated_access = true
  allow_github_webhooks        = true
  allow_repo_config            = true

  custom_environment_variables = [
    {
      name  = "AWS_CONFIG_FILE",
      value = "/data/scrubed"
    },
    {
      name  = "AWS_SDK_LOAD_CONFIG",
      value = "1",
    }
  ]

  volumes_from = [
    {
      sourceContainer = "atlantis_sidecar",
      readOnly = true,
    }
  ]
}
```