### PR TITLE
fix: Optionally lookup for the latest task definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ allow_github_webhooks        = true
 | ecs\_task\_memory | The amount (in MiB) of memory used by the task | `number` | `512` | no |
 | entrypoint | The entry point that is passed to the container | `list(string)` | `null` | no |
 | essential | Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value | `bool` | `true` | no |
+| external\_task\_definition\_updates | Enable to allow the task definition to be updated outside of this Terraform module | `bool` | `false` | no |
 | firelens\_configuration | The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html | <pre>object({<br>    type    = string<br>    options = map(string)<br>  })</pre> | `null` | no |
 | github\_webhooks\_cidr\_blocks | List of CIDR blocks used by GitHub webhooks | `list(string)` | <pre>[<br>  "140.82.112.0/20",<br>  "185.199.108.0/22",<br>  "192.30.252.0/22"<br>]</pre> | no |
 | internal | Whether the load balancer is internal or external | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,9 @@ locals {
     },
   ]
 
+  # ECS task definition
+  latest_task_definition_rev = var.external_task_definition_updates ? max(aws_ecs_task_definition.atlantis.revision, data.aws_ecs_task_definition.atlantis[0].revision) : aws_ecs_task_definition.atlantis.revision
+
   # Secret access tokens
   container_definition_secrets_1 = local.secret_name_key != "" && local.secret_name_value_from != "" ? [
     {
@@ -563,6 +566,8 @@ resource "aws_ecs_task_definition" "atlantis" {
 }
 
 data "aws_ecs_task_definition" "atlantis" {
+  count = var.external_task_definition_updates ? 1 : 0
+
   task_definition = var.name
 
   depends_on = [aws_ecs_task_definition.atlantis]
@@ -571,10 +576,8 @@ data "aws_ecs_task_definition" "atlantis" {
 resource "aws_ecs_service" "atlantis" {
   name    = var.name
   cluster = module.ecs.this_ecs_cluster_id
-  task_definition = "${data.aws_ecs_task_definition.atlantis.family}:${max(
-    aws_ecs_task_definition.atlantis.revision,
-    data.aws_ecs_task_definition.atlantis.revision,
-  )}"
+
+  task_definition                    = "${var.name}:${local.latest_task_definition_rev}"
   desired_count                      = var.ecs_service_desired_count
   launch_type                        = "FARGATE"
   deployment_maximum_percent         = var.ecs_service_deployment_maximum_percent

--- a/variables.tf
+++ b/variables.tf
@@ -381,6 +381,12 @@ variable "ulimits" {
   default = null
 }
 
+variable "external_task_definition_updates" {
+  description = "Enable to allow the task definition to be updated outside of this Terraform module. This should be enabled when using a deployment tool such as ecs-deploy which updates the task definition and will then keep the ECS service using the latest version of the task definition."
+  type        = bool
+  default     = false
+}
+
 # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html
 variable "firelens_configuration" {
   description = "The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html"


### PR DESCRIPTION
## Description

A data lookup for the latest task definition revision to be used in the
ECS service was enabled by default, which continually appeared in
plans/applies.

This is used when the task definition's updated by an external
deployment tool, so this is now disabled and requires enabling the
`external_task_definition_updates` variable so the default behaviour is
quiet.

## Motivation and Context

A fix for #72 as an alternative to #124 which removed the functionality for external deployment tools.

I don't need the external tool support, but I am trying to make the default behaviour quieter and not show this update on every run.

## Breaking Changes

Yes, for people using external deployment tools, they should set this new `external_task_definition_updates` variable to true. This feels like the exception as the default behaviour of the module is to deploy the task definition itself.

## How Has This Been Tested?

Two tests, one with the default behaviour (`external_task_definition_updates` set to false) and verified with a `plan` that there are no proposed changes/noise:

```
No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```

and again with it set to true shows the previous behaviour:

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place
 <= read (data resources)

Terraform will perform the following actions:

  # module.atlantis.data.aws_ecs_task_definition.atlantis[0] will be read during apply
  # (config refers to values not yet known)
 <= data "aws_ecs_task_definition" "atlantis"  {
      + family          = (known after apply)
      + id              = (known after apply)
      + network_mode    = (known after apply)
      + revision        = (known after apply)
      + status          = (known after apply)
      + task_definition = "atlantis"
      + task_role_arn   = (known after apply)
    }

  # module.atlantis.aws_ecs_service.atlantis will be updated in-place
  ~ resource "aws_ecs_service" "atlantis" {
        cluster                            = "arn:aws:ecs:eu-west-1:...:cluster/atlantis"
        deployment_maximum_percent         = 200
        deployment_minimum_healthy_percent = 50
        desired_count                      = 1
        enable_ecs_managed_tags            = false
        health_check_grace_period_seconds  = 0
        iam_role                           = "aws-service-role"
        id                                 = "arn:aws:ecs:eu-west-1:...:service/atlantis/atlantis"
        launch_type                        = "FARGATE"
        name                               = "atlantis"
        platform_version                   = "LATEST"
        propagate_tags                     = "NONE"
        scheduling_strategy                = "REPLICA"
        tags                               = {
            "Name" = "atlantis"
        }
      ~ task_definition                    = "atlantis:3" -> (known after apply)

        deployment_controller {
            type = "ECS"
        }

        load_balancer {
            container_name   = "atlantis"
            container_port   = 4141
            target_group_arn = "arn:aws:elasticloadbalancing:eu-west-1:...:targetgroup/atlantis/5af07546b36138a7"
        }

        network_configuration {
            assign_public_ip = false
            security_groups  = [
                "sg-063b57edb4bf146f1",
            ]
            subnets          = [
                "subnet-03b28a46d19970c62",
                "subnet-0c1bf5c14d0d97232",
                "subnet-0fa2dd26cbd903e82",
            ]
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```