### PR TITLE
fix: secret policy not created with github bot

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -424,7 +424,7 @@ data "aws_iam_policy_document" "ecs_task_access_secrets_with_kms" {
 }
 
 resource "aws_iam_role_policy" "ecs_task_access_secrets" {
-  count = var.atlantis_github_user_token != "" || var.atlantis_gitlab_user_token != "" || var.atlantis_bitbucket_user_token != "" ? 1 : 0
+  count = var.atlantis_github_webhook_secret != "" || var.atlantis_github_user_token != "" || var.atlantis_gitlab_user_token != "" || var.atlantis_bitbucket_user_token != "" ? 1 : 0
 
   name = "ECSTaskAccessSecretsPolicy"
 


### PR DESCRIPTION
## Description

With the addition of https://github.com/terraform-aws-modules/terraform-aws-atlantis/pull/151, we can now specify an `atlantis_github_webhook_secret`, however, with only this parameter the policy to access the secret in SSM is never created.

The policy will only be created when `atlantis_github_user_token` is specified, which isn't necessary for a GitHub Bot.

## Motivation and Context
To run Atlantis as a Github App you only need to supply 3 variables, `ATLANTIS_GH_APP_ID`, `ATLANTIS_GH_APP_KEY_FILE` and `atlantis_github_webhook_secret`. With this setup, Atlantis should be able to access the webhook secret via SSM.

## Breaking Changes
n/a

## How Has This Been Tested?
Specifying an `atlantis_github_webhook_secret` will now attach the appropriate policy.