### PR TITLE
feat: Pass additional target groups as parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ allow_github_webhooks        = true
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | acm\_certificate\_domain\_name | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance. Specify if it is different from value in `route53_zone_name` | `string` | `""` | no |
+| additional\_target\_group\_arns | List of additional target group arns to connect with the ecs_service | `list(string)` | `[]` | no |
 | alb\_authenticate\_cognito | Map of AWS Cognito authentication parameters to protect ALB (eg, using SAML). See https://www.terraform.io/docs/providers/aws/r/lb_listener.html#authenticate-cognito-action | `any` | `{}` | no |
 | alb\_authenticate\_oidc | Map of Authenticate OIDC parameters to protect ALB (eg, using Auth0). See https://www.terraform.io/docs/providers/aws/r/lb_listener.html#authenticate-oidc-action | `any` | `{}` | no |
 | alb\_http\_security\_group\_tags | Additional tags to put on the http security group | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -592,10 +592,13 @@ resource "aws_ecs_service" "atlantis" {
     assign_public_ip = var.ecs_service_assign_public_ip
   }
 
-  load_balancer {
-    container_name   = var.name
-    container_port   = var.atlantis_port
-    target_group_arn = element(module.alb.target_group_arns, 0)
+  dynamic "load_balancer" {
+    for_each = concat(module.alb.target_group_arns, var.additional_target_group_arns)
+    content {
+      container_name = var.name
+      container_port = var.atlantis_port
+      target_group_arn = load_balancer.value
+    }
   }
 
   dynamic "capacity_provider_strategy" {

--- a/variables.tf
+++ b/variables.tf
@@ -535,3 +535,9 @@ variable "security_group_ids" {
   type        = list(string)
   default     = []
 }
+
+variable "additional_target_group_arns" {
+  description = "List of additional target group arns to connect with the ecs_service"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Description
I have added the ability to pass in `additional_target_group_arns` to connect to the ecs_service. 

## Motivation and Context
As a part of existing infrastructure, this allows me to use the default group as a public endpoint for whitelisted IPs and also pass in additional target groups to integrate with an existing internal network.

## Breaking Changes
Does this break backwards compatibility with the current major version? No

## How Has This Been Tested?
I am currently using this module in my infrastructure. I forked the latest version (v2.26.0). Then used the fork to make changes to my current infrastructure. It worked without any issues. This was a small change that only adds additional target groups and should not affect the current layout/resources defined by this module. I also tested by updating to this forked version without adding the new argument and no changes occurred. So no breaking changes.
