### PR TITLE
feat: allow setting container memory & cpu from task memory & cpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,20 +195,20 @@ allow_github_webhooks        = true
 
 | Name |
 |------|
-| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/2.68/docs/resources/cloudwatch_log_group) |
-| [aws_ecs_service](https://registry.terraform.io/providers/hashicorp/aws/2.68/docs/resources/ecs_service) |
-| [aws_ecs_task_definition](https://registry.terraform.io/providers/hashicorp/aws/2.68/docs/data-sources/ecs_task_definition) |
-| [aws_ecs_task_definition](https://registry.terraform.io/providers/hashicorp/aws/2.68/docs/resources/ecs_task_definition) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.68/docs/data-sources/iam_policy_document) |
-| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.68/docs/resources/iam_role_policy_attachment) |
-| [aws_iam_role_policy](https://registry.terraform.io/providers/hashicorp/aws/2.68/docs/resources/iam_role_policy) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/2.68/docs/resources/iam_role) |
-| [aws_lb_listener_rule](https://registry.terraform.io/providers/hashicorp/aws/2.68/docs/resources/lb_listener_rule) |
-| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/2.68/docs/data-sources/region) |
-| [aws_route53_record](https://registry.terraform.io/providers/hashicorp/aws/2.68/docs/resources/route53_record) |
-| [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/2.68/docs/data-sources/route53_zone) |
-| [aws_ssm_parameter](https://registry.terraform.io/providers/hashicorp/aws/2.68/docs/resources/ssm_parameter) |
-| [random_id](https://registry.terraform.io/providers/hashicorp/random/2.0/docs/resources/id) |
+| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) |
+| [aws_ecs_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) |
+| [aws_ecs_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_task_definition) |
+| [aws_ecs_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
+| [aws_iam_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
+| [aws_lb_listener_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) |
+| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
+| [aws_route53_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) |
+| [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) |
+| [aws_ssm_parameter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) |
+| [random_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) |
 
 ## Inputs
 
@@ -254,7 +254,9 @@ allow_github_webhooks        = true
 | cidr | The CIDR block for the VPC which will be created if `vpc_id` is not specified | `string` | `""` | no |
 | cloudwatch\_log\_retention\_in\_days | Retention period of Atlantis CloudWatch logs | `number` | `7` | no |
 | command | The command that is passed to the container | `list(string)` | `null` | no |
+| container\_cpu | The number of cpu units used by the atlantis container. If not specified ecs\_task\_cpu will be used | `number` | `null` | no |
 | container\_depends\_on | The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed. The condition can be one of START, COMPLETE, SUCCESS or HEALTHY | <pre>list(object({<br>    containerName = string<br>    condition     = string<br>  }))</pre> | `null` | no |
+| container\_memory | The amount (in MiB) of memory used by the atlantis container. If not specified ecs\_task\_memory will be used | `number` | `null` | no |
 | container\_memory\_reservation | The amount of memory (in MiB) to reserve for the container | `number` | `128` | no |
 | create\_route53\_record | Whether to create Route53 record for Atlantis | `bool` | `true` | no |
 | custom\_container\_definitions | A list of valid container definitions provided as a single valid JSON document. By default, the standard container definition is used. | `string` | `""` | no |

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -51,10 +51,10 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 
 | Name |
 |------|
-| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/2.68/docs/data-sources/caller_identity) |
-| [aws_elb_service_account](https://registry.terraform.io/providers/hashicorp/aws/2.68/docs/data-sources/elb_service_account) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.68/docs/data-sources/iam_policy_document) |
-| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/2.68/docs/data-sources/region) |
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
+| [aws_elb_service_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_service_account) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
+| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
 
 ## Inputs
 

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -40,6 +40,8 @@ module "atlantis" {
   ecs_task_cpu                 = 512
   ecs_task_memory              = 1024
   container_memory_reservation = 256
+  container_cpu                = 512
+  container_memory             = 1024
 
   entrypoint        = ["docker-entrypoint.sh"]
   command           = ["server"]

--- a/main.tf
+++ b/main.tf
@@ -449,8 +449,8 @@ module "container_definition_github_gitlab" {
   container_name  = var.name
   container_image = local.atlantis_image
 
-  container_cpu                = var.ecs_task_cpu
-  container_memory             = var.ecs_task_memory
+  container_cpu                = var.container_cpu != null ? var.container_cpu : var.ecs_task_cpu
+  container_memory             = var.container_memory != null ? var.container_memory : var.ecs_task_memory
   container_memory_reservation = var.container_memory_reservation
 
   user                     = var.user
@@ -506,8 +506,8 @@ module "container_definition_bitbucket" {
   container_name  = var.name
   container_image = local.atlantis_image
 
-  container_cpu                = var.ecs_task_cpu
-  container_memory             = var.ecs_task_memory
+  container_cpu                = var.container_cpu != null ? var.container_cpu : var.ecs_task_cpu
+  container_memory             = var.container_memory != null ? var.container_memory : var.ecs_task_memory
   container_memory_reservation = var.container_memory_reservation
 
   user                     = var.user

--- a/modules/github-repository-webhook/README.md
+++ b/modules/github-repository-webhook/README.md
@@ -22,7 +22,7 @@ No Modules.
 
 | Name |
 |------|
-| [github_repository_webhook](https://registry.terraform.io/providers/integrations/github/2.4.1/docs/resources/repository_webhook) |
+| [github_repository_webhook](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_webhook) |
 
 ## Inputs
 

--- a/modules/gitlab-repository-webhook/README.md
+++ b/modules/gitlab-repository-webhook/README.md
@@ -22,7 +22,7 @@ No Modules.
 
 | Name |
 |------|
-| [gitlab_project_hook](https://registry.terraform.io/providers/gitlabhq/gitlab/3.0/docs/resources/project_hook) |
+| [gitlab_project_hook](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_hook) |
 
 ## Inputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -299,6 +299,18 @@ variable "ecs_task_memory" {
   default     = 512
 }
 
+variable "container_cpu" {
+  description = "The number of cpu units used by the atlantis container. If not specified ecs_task_cpu will be used"
+  type        = number
+  default     = null
+}
+
+variable "container_memory" {
+  description = "The amount (in MiB) of memory used by the atlantis container. If not specified ecs_task_memory will be used"
+  type        = number
+  default     = null
+}
+
 variable "container_memory_reservation" {
   description = "The amount of memory (in MiB) to reserve for the container"
   type        = number


### PR DESCRIPTION
## Description
With the addition of #162 if a user includes extra container definitions and those definitions require CPU/Memory allocations the deployment will fail as the atlantis container definition takes the entire task cpu and memory allocation.

## Motivation and Context
This allows a user to optionally fine tune the allocations of cpu and memory for the atlantis container definition. Most users won't require this feature, unless they're using `extra_container_definitions`.

fixes #168 

## Breaking Changes
This does not break compatibility as by default the values are `null` and if `null` they will default to the `ecs_task_*` definitions, as it was before this change.

## How Has This Been Tested?

```hcl
module "datadog_fargate_container_definition" {
  source  = "cloudposse/ecs-container-definition/aws"
  version = "v0.41.0"

  container_name  = "datadog-agent"
  container_image = "datadog/agent:latest"

  container_memory_reservation = 256
  container_cpu                = 10

  essential = true

  environment = [
    {
      name  = "ECS_FARGATE"
      value = "true"
    }
  ]
}

module "atlantis" {
  source = "github.com/stacklet/terraform-aws-atlantis?ref=issue-168"

  name = "atlantis"

  # DNS
  route53_zone_name = "example.com"

  # Atlantis
  extra_container_definitions = [module.datadog_fargate_container_definition.json_map_object]
  atlantis_github_user           = "marcoceppi"
  atlantis_github_user_token     = data.aws_kms_secrets.atlantis.plaintext["github_user_token"]

  atlantis_hide_prev_plan_comments = "true"

  container_cpu    = 502
  container_memory = 768

  ecs_task_cpu    = 512
  ecs_task_memory = 1024

  allow_repo_config = "true"
}
```