### PR TITLE
feat: support custom platform version

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ allow_github_webhooks        = true
 | ecs\_service\_deployment\_maximum\_percent | The upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a service during a deployment | `number` | `200` | no |
 | ecs\_service\_deployment\_minimum\_healthy\_percent | The lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment | `number` | `50` | no |
 | ecs\_service\_desired\_count | The number of instances of the task definition to place and keep running | `number` | `1` | no |
+| ecs\_service\_platform\_version | The platform version on which to run your service | `string` | `"LATEST"` | no |
 | ecs\_task\_cpu | The number of cpu units used by the task | `number` | `256` | no |
 | ecs\_task\_memory | The amount (in MiB) of memory used by the task | `number` | `512` | no |
 | entrypoint | The entry point that is passed to the container | `list(string)` | `null` | no |

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -35,6 +35,7 @@ module "atlantis" {
   public_subnets  = ["10.20.101.0/24", "10.20.102.0/24", "10.20.103.0/24"]
 
   # ECS
+  ecs_service_platform_version = "LATEST"
   ecs_container_insights       = true
   ecs_task_cpu                 = 512
   ecs_task_memory              = 1024

--- a/main.tf
+++ b/main.tf
@@ -583,6 +583,7 @@ resource "aws_ecs_service" "atlantis" {
   )}"
   desired_count                      = var.ecs_service_desired_count
   launch_type                        = var.ecs_fargate_spot ? null : "FARGATE"
+  platform_version                   = var.ecs_service_platform_version
   deployment_maximum_percent         = var.ecs_service_deployment_maximum_percent
   deployment_minimum_healthy_percent = var.ecs_service_deployment_minimum_healthy_percent
 

--- a/variables.tf
+++ b/variables.tf
@@ -263,6 +263,12 @@ variable "ecs_service_desired_count" {
   default     = 1
 }
 
+variable "ecs_service_platform_version" {
+  description = "The platform version on which to run your service"
+  type        = string
+  default     = "LATEST"
+}
+
 variable "ecs_service_deployment_maximum_percent" {
   description = "The upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a service during a deployment"
   type        = number


### PR DESCRIPTION
## Description
Allow to set custom ECS Fargate platform version

## Motivation and Context
currently, by default, ECS Fargate is using platform version 1.3.0
However, 1.4.0 introduce more features I would like Atlantis to use, including
- For tasks using platform version 1.4.0 or later that are launched on May 28, 2020 or later, the **ephemeral storage is encrypted with an AES-256 encryption algorithm** using an AWS Fargate-managed encryption key

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-task-storage.html

## Breaking Changes
Nope, new variables are backward compatible and match existing defaults

## How Has This Been Tested?
planed and applied