### PR TITLE
fix: Update module dependencies for TF 0.14 support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -186,7 +186,7 @@ module "vpc" {
 ###################
 module "alb" {
   source  = "terraform-aws-modules/alb/aws"
-  version = "v5.7.0"
+  version = "v5.10.0"
 
   name     = var.name
   internal = var.internal
@@ -264,7 +264,7 @@ resource "aws_lb_listener_rule" "unauthenticated_access_for_cidr_blocks" {
 ###################
 module "alb_https_sg" {
   source  = "terraform-aws-modules/security-group/aws//modules/https-443"
-  version = "v3.15.0"
+  version = "v3.17.0"
 
   name        = "${var.name}-alb-https"
   vpc_id      = local.vpc_id
@@ -277,7 +277,7 @@ module "alb_https_sg" {
 
 module "alb_http_sg" {
   source  = "terraform-aws-modules/security-group/aws//modules/http-80"
-  version = "v3.15.0"
+  version = "v3.17.0"
 
   name        = "${var.name}-alb-http"
   vpc_id      = local.vpc_id
@@ -290,7 +290,7 @@ module "alb_http_sg" {
 
 module "atlantis_sg" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "v3.15.0"
+  version = "v3.17.0"
 
   name        = var.name
   vpc_id      = local.vpc_id
@@ -316,7 +316,7 @@ module "atlantis_sg" {
 ###################
 module "acm" {
   source  = "terraform-aws-modules/acm/aws"
-  version = "v2.10.0"
+  version = "v2.12.0"
 
   create_certificate = var.certificate_arn == ""
 
@@ -443,7 +443,7 @@ resource "aws_iam_role_policy" "ecs_task_access_secrets" {
 
 module "container_definition_github_gitlab" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "v0.40.0"
+  version = "v0.45.2"
 
   container_name  = var.name
   container_image = local.atlantis_image
@@ -500,7 +500,7 @@ module "container_definition_github_gitlab" {
 
 module "container_definition_bitbucket" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "v0.40.0"
+  version = "v0.45.2"
 
   container_name  = var.name
   container_image = local.atlantis_image

--- a/main.tf
+++ b/main.tf
@@ -164,7 +164,7 @@ resource "aws_ssm_parameter" "atlantis_bitbucket_user_token" {
 ###################
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "v2.47.0"
+  version = "v2.64.0"
 
   create_vpc = var.vpc_id == ""
 


### PR DESCRIPTION
## Description

This PR updates module dependencies to provide support for Terraform 0.14.

## Motivation and Context

The versions of module dependencies that are used now set the `required_version` parameter as `< 0.14.0`, which means we cannot use the module with Terraform 0.14.

## Breaking Changes

Does not break compatibility: the new versions are all backwards-compatible.

## How Has This Been Tested?

Tested with `terraform validate` on Terraform 0.14.
