### PR TITLE
feat: Add permissions boundary to ecs task iam role

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ allow_github_webhooks        = true
 | internal | Whether the load balancer is internal or external | `bool` | `false` | no |
 | mount\_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume`. The `readOnly` key is optional. | `list` | `[]` | no |
 | name | Name to use on all resources created (VPC, ALB, etc) | `string` | `"atlantis"` | no |
+| permissions\_boundary | If provided, all IAM roles will be created with this permissions boundary attached. | `string` | `null` | no |
 | policies\_arn | A list of the ARN of the policies you want to apply | `list(string)` | <pre>[<br>  "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"<br>]</pre> | no |
 | private\_subnet\_ids | A list of IDs of existing private subnets inside the VPC | `list(string)` | `[]` | no |
 | private\_subnets | A list of private subnets inside the VPC | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -379,8 +379,9 @@ data "aws_iam_policy_document" "ecs_tasks" {
 }
 
 resource "aws_iam_role" "ecs_task_execution" {
-  name               = "${var.name}-ecs_task_execution"
-  assume_role_policy = data.aws_iam_policy_document.ecs_tasks.json
+  name                 = "${var.name}-ecs_task_execution"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_tasks.json
+  permissions_boundary = var.permissions_boundary
 
   tags = local.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -233,6 +233,12 @@ variable "ecs_service_assign_public_ip" {
   default     = false
 }
 
+variable "permissions_boundary" {
+  description = "If provided, all IAM roles will be created with this permissions boundary attached."
+  type        = string
+  default     = null
+}
+
 variable "policies_arn" {
   description = "A list of the ARN of the policies you want to apply"
   type        = list(string)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added permissions boundary to iam role resource

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Certain organisations require iam roles to be created with permissions boundary. This PR seeks to address those use cases

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
As the variable is optional, there will be no changes to existing resources

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by using in my own infrastructure