### PR TITLE
chore: correct versions used and required versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ allow_github_webhooks        = true
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13 |
 | aws | >= 2.68 |
 | random | >= 2.0 |
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ allow_github_webhooks        = true
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.7 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.68 |
 | random | >= 2.0 |
 

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -29,7 +29,7 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13 |
 | aws | >= 2.68 |
 | github | >= 2.4.1 |
 

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -29,8 +29,9 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.7 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.68 |
+| github | >= 2.4.1 |
 
 ## Providers
 

--- a/examples/github-complete/versions.tf
+++ b/examples/github-complete/versions.tf
@@ -1,7 +1,8 @@
 terraform {
-  required_version = ">= 0.12.7"
+  required_version = ">= 0.12.26"
 
   required_providers {
-    aws = ">= 2.68"
+    aws    = ">= 2.68"
+    github = ">= 2.4.1"
   }
 }

--- a/examples/github-complete/versions.tf
+++ b/examples/github-complete/versions.tf
@@ -1,8 +1,15 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws    = ">= 2.68"
-    github = ">= 2.4.1"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.68"
+    }
+
+    github = {
+      source  = "integrations/github"
+      version = ">= 2.4.1"
+    }
   }
 }

--- a/examples/github-repository-webhook/README.md
+++ b/examples/github-repository-webhook/README.md
@@ -21,7 +21,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13 |
 | aws | >= 2.68 |
 | github | >= 2.4.1 |
 

--- a/examples/github-repository-webhook/README.md
+++ b/examples/github-repository-webhook/README.md
@@ -21,8 +21,9 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.7 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.68 |
+| github | >= 2.4.1 |
 
 ## Providers
 

--- a/examples/github-repository-webhook/versions.tf
+++ b/examples/github-repository-webhook/versions.tf
@@ -1,7 +1,8 @@
 terraform {
-  required_version = ">= 0.12.7"
+  required_version = ">= 0.12.26"
 
   required_providers {
-    aws = ">= 2.68"
+    aws    = ">= 2.68"
+    github = ">= 2.4.1"
   }
 }

--- a/examples/github-repository-webhook/versions.tf
+++ b/examples/github-repository-webhook/versions.tf
@@ -1,8 +1,15 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws    = ">= 2.68"
-    github = ">= 2.4.1"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.68"
+    }
+
+    github = {
+      source  = "integrations/github"
+      version = ">= 2.4.1"
+    }
   }
 }

--- a/examples/gitlab-repository-webhook/README.md
+++ b/examples/gitlab-repository-webhook/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13 |
 | aws | >= 2.68 |
 | gitlab | >= 2.0 |
 

--- a/examples/gitlab-repository-webhook/README.md
+++ b/examples/gitlab-repository-webhook/README.md
@@ -19,8 +19,9 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.7 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.68 |
+| gitlab | >= 2.0 |
 
 ## Providers
 

--- a/examples/gitlab-repository-webhook/README.md
+++ b/examples/gitlab-repository-webhook/README.md
@@ -21,7 +21,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | terraform | >= 0.13 |
 | aws | >= 2.68 |
-| gitlab | >= 2.0 |
+| gitlab | >= 3.0 |
 
 ## Providers
 

--- a/examples/gitlab-repository-webhook/versions.tf
+++ b/examples/gitlab-repository-webhook/versions.tf
@@ -1,8 +1,15 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws    = ">= 2.68"
-    gitlab = ">= 2.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.68"
+    }
+
+    gitlab = {
+      source  = "gitlabhq/gitlab"
+      version = ">= 2.0"
+    }
   }
 }

--- a/examples/gitlab-repository-webhook/versions.tf
+++ b/examples/gitlab-repository-webhook/versions.tf
@@ -1,7 +1,8 @@
 terraform {
-  required_version = ">= 0.12.7"
+  required_version = ">= 0.12.26"
 
   required_providers {
-    aws = ">= 2.68"
+    aws    = ">= 2.68"
+    gitlab = ">= 2.0"
   }
 }

--- a/examples/gitlab-repository-webhook/versions.tf
+++ b/examples/gitlab-repository-webhook/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     gitlab = {
       source  = "gitlabhq/gitlab"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
   }
 }

--- a/modules/github-repository-webhook/README.md
+++ b/modules/github-repository-webhook/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13 |
 | github | >= 2.4.1 |
 
 ## Providers
@@ -22,7 +22,7 @@ No Modules.
 
 | Name |
 |------|
-| [github_repository_webhook](https://registry.terraform.io/providers/hashicorp/github/2.4.1/docs/resources/repository_webhook) |
+| [github_repository_webhook](https://registry.terraform.io/providers/integrations/github/2.4.1/docs/resources/repository_webhook) |
 
 ## Inputs
 

--- a/modules/github-repository-webhook/README.md
+++ b/modules/github-repository-webhook/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.7 |
+| terraform | >= 0.12.26 |
 | github | >= 2.4.1 |
 
 ## Providers

--- a/modules/github-repository-webhook/versions.tf
+++ b/modules/github-repository-webhook/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.7"
+  required_version = ">= 0.12.26"
 
   required_providers {
     github = ">= 2.4.1"

--- a/modules/github-repository-webhook/versions.tf
+++ b/modules/github-repository-webhook/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
-    github = ">= 2.4.1"
+    github = {
+      source  = "integrations/github"
+      version = ">= 2.4.1"
+    }
   }
 }

--- a/modules/gitlab-repository-webhook/README.md
+++ b/modules/gitlab-repository-webhook/README.md
@@ -5,13 +5,14 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
+| terraform | >= 0.12.26 |
+| gitlab | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| gitlab | n/a |
+| gitlab | >= 2.0 |
 
 ## Modules
 
@@ -21,7 +22,7 @@ No Modules.
 
 | Name |
 |------|
-| [gitlab_project_hook](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_hook) |
+| [gitlab_project_hook](https://registry.terraform.io/providers/hashicorp/gitlab/2.0/docs/resources/project_hook) |
 
 ## Inputs
 

--- a/modules/gitlab-repository-webhook/README.md
+++ b/modules/gitlab-repository-webhook/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13 |
-| gitlab | >= 2.0 |
+| gitlab | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| gitlab | >= 2.0 |
+| gitlab | >= 3.0 |
 
 ## Modules
 
@@ -22,7 +22,7 @@ No Modules.
 
 | Name |
 |------|
-| [gitlab_project_hook](https://registry.terraform.io/providers/gitlabhq/gitlab/2.0/docs/resources/project_hook) |
+| [gitlab_project_hook](https://registry.terraform.io/providers/gitlabhq/gitlab/3.0/docs/resources/project_hook) |
 
 ## Inputs
 

--- a/modules/gitlab-repository-webhook/README.md
+++ b/modules/gitlab-repository-webhook/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13 |
 | gitlab | >= 2.0 |
 
 ## Providers
@@ -22,7 +22,7 @@ No Modules.
 
 | Name |
 |------|
-| [gitlab_project_hook](https://registry.terraform.io/providers/hashicorp/gitlab/2.0/docs/resources/project_hook) |
+| [gitlab_project_hook](https://registry.terraform.io/providers/gitlabhq/gitlab/2.0/docs/resources/project_hook) |
 
 ## Inputs
 

--- a/modules/gitlab-repository-webhook/versions.tf
+++ b/modules/gitlab-repository-webhook/versions.tf
@@ -1,9 +1,7 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.12.26"
 
   required_providers {
-    gitlab = {
-      source = "gitlabhq/gitlab"
-    }
+    gitlab = ">= 2.0"
   }
 }

--- a/modules/gitlab-repository-webhook/versions.tf
+++ b/modules/gitlab-repository-webhook/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
-    gitlab = ">= 2.0"
+    gitlab = {
+      source  = "gitlabhq/gitlab"
+      version = ">= 2.0"
+    }
   }
 }

--- a/modules/gitlab-repository-webhook/versions.tf
+++ b/modules/gitlab-repository-webhook/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     gitlab = {
       source  = "gitlabhq/gitlab"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,8 +1,15 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws    = ">= 2.68"
-    random = ">= 2.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.68"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.0"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.7"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 2.68"


### PR DESCRIPTION
## Description
- update and correct versions used and required versions
- bump min version of terraform to 0.13 since it looks like GitLab does not support 0.12

## Motivation and Context
- status checks are currently failing validation and this is intended to fix that

## Breaking Changes
- Terraform 0.13 is min required version now

## How Has This Been Tested?
- ci-cd status checks
