### PR TITLE
feat: allow adding more trusted principals to task role

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,30 +7,30 @@ on:
       - master
 
 jobs:
-# Min Terraform version(s)
+  # Min Terraform version(s)
   getDirectories:
-      name: Get root directories
-      runs-on: ubuntu-latest
-      steps:
-          - name: Checkout
-            uses: actions/checkout@v2
-          - name: Install Python
-            uses: actions/setup-python@v2
-          - name: Build matrix
-            id: matrix
-            run: |
-              DIRS=$(python -c "import json; import glob; print(json.dumps([x.replace('/versions.tf', '') for x in glob.glob('./**/versions.tf', recursive=True)]))")
-              echo "::set-output name=directories::$DIRS"
-      outputs:
-          directories: ${{ steps.matrix.outputs.directories }}
+    name: Get root directories
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Python
+        uses: actions/setup-python@v2
+      - name: Build matrix
+        id: matrix
+        run: |
+          DIRS=$(python -c "import json; import glob; print(json.dumps([x.replace('/versions.tf', '') for x in glob.glob('./**/versions.tf', recursive=True)]))")
+          echo "::set-output name=directories::$DIRS"
+    outputs:
+      directories: ${{ steps.matrix.outputs.directories }}
 
   preCommitMinVersions:
     name: Min TF validate
     needs: getDirectories
     runs-on: ubuntu-latest
     strategy:
-        matrix:
-            directory: ${{ fromJson(needs.getDirectories.outputs.directories) }}
+      matrix:
+        directory: ${{ fromJson(needs.getDirectories.outputs.directories) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -59,7 +59,7 @@ jobs:
           pre-commit run terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)
 
 
-# Max Terraform version
+  # Max Terraform version
   getBaseVersion:
     name: Module max TF version
     runs-on: ubuntu-latest
@@ -94,7 +94,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12.0-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12\..+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ allow_github_webhooks        = true
 | <a name="input_start_timeout"></a> [start\_timeout](#input\_start\_timeout) | Time duration (in seconds) to wait before giving up on resolving dependencies for a container | `number` | `30` | no |
 | <a name="input_stop_timeout"></a> [stop\_timeout](#input\_stop\_timeout) | Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own | `number` | `30` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to use on all resources | `map(string)` | `{}` | no |
+| <a name="input_trusted_entities"></a> [trusted\_entities](#input\_trusted\_entities) | A list of  users or roles, that can assume the task role | `list(string)` | `[]` | no |
 | <a name="input_trusted_principals"></a> [trusted\_principals](#input\_trusted\_principals) | A list of principals, in addition to ecs-tasks.amazonaws.com, that can assume the task role | `list(string)` | `[]` | no |
 | <a name="input_ulimits"></a> [ulimits](#input\_ulimits) | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | <pre>list(object({<br>    name      = string<br>    hardLimit = number<br>    softLimit = number<br>  }))</pre> | `null` | no |
 | <a name="input_user"></a> [user](#input\_user) | The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group. The default (null) will use the container's configured `USER` directive or root if not set. | `string` | `null` | no |

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -67,6 +67,7 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token | `string` | n/a | yes |
 | <a name="input_github_user"></a> [github\_user](#input\_github\_user) | Github user for Atlantis to utilize when performing Github activities | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS region where resources will be created | `string` | `"us-east-1"` | no |
+| <a name="input_trusted_entities"></a> [trusted\_entities](#input\_trusted\_entities) | A list of  users or roles, that can assume the task role | `list(string)` | `[]` | no |
 | <a name="input_trusted_principals"></a> [trusted\_principals](#input\_trusted\_principals) | A list of principals, in addition to ecs-tasks.amazonaws.com, that can assume the task role | `list(string)` | n/a | yes |
 
 ## Outputs

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -64,6 +64,7 @@ module "atlantis" {
 
   # Security
   trusted_principals = var.trusted_principals
+  trusted_entities   = var.trusted_entities
 
   # DNS
   route53_zone_name = var.domain

--- a/examples/github-complete/variables.tf
+++ b/examples/github-complete/variables.tf
@@ -38,3 +38,9 @@ variable "trusted_principals" {
   description = "A list of principals, in addition to ecs-tasks.amazonaws.com, that can assume the task role"
   type        = list(string)
 }
+
+variable "trusted_entities" {
+  description = "A list of  users or roles, that can assume the task role"
+  type        = list(string)
+  default     = []
+}

--- a/main.tf
+++ b/main.tf
@@ -378,6 +378,15 @@ data "aws_iam_policy_document" "ecs_tasks" {
       type        = "Service"
       identifiers = compact(distinct(concat(["ecs-tasks.amazonaws.com"], var.trusted_principals)))
     }
+
+    dynamic "principals" {
+      for_each = var.trusted_entities
+
+      content {
+        type        = "AWS"
+        identifiers = compact(distinct(var.trusted_entities))
+      }
+    }
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -380,11 +380,11 @@ data "aws_iam_policy_document" "ecs_tasks" {
     }
 
     dynamic "principals" {
-      for_each = var.trusted_entities
+      for_each = length(var.trusted_entities) > 0 ? [true] : []
 
       content {
         type        = "AWS"
-        identifiers = compact(distinct(var.trusted_entities))
+        identifiers = var.trusted_entities
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -251,6 +251,12 @@ variable "trusted_principals" {
   default     = []
 }
 
+variable "trusted_entities" {
+  description = "A list of  users or roles, that can assume the task role"
+  type        = list(string)
+  default     = []
+}
+
 variable "ecs_fargate_spot" {
   description = "Whether to run ECS Fargate Spot or not"
   type        = bool


### PR DESCRIPTION
This is a copy of a PR from @kainlite (link below). The original PR did not allow for an empty value for *trusted_entities*. I created this separate PR because I did not honestly know how to contribute to another users PR.

https://github.com/terraform-aws-modules/terraform-aws-atlantis/pull/173#issue-543010427

## Description
This is adding another variable to be able to give some users or other roles the ability to assume the Atlantis role.

## Motivation and Context
While debugging it comes handy to be able to invoke terraform as Atlantis does to speed things up, also this is particularly useful when importing resources.

## Breaking Changes
None

## How Has This Been Tested?
Tested referencing my own branch.