### PR TITLE
fix: Rename option Organization to Owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ cd terraform-aws-atlantis
 
 5. Run `terraform output atlantis_url` to get URL where Atlantis is publicly reachable. (Note: It may take a minute or two to get it reachable for the first time)
 
-6. Github webhook is automatically created if `github_token`, `github_organization` and `github_repo_names` were specified. Read [Add GitHub Webhook](https://github.com/runatlantis/atlantis#add-github-webhook) in the official Atlantis documentation or check [example "GitHub repository webhook for Atlantis"](https://github.com/terraform-aws-modules/terraform-aws-atlantis/tree/master/examples/github-repository-webhook) to add more webhooks.
+6. Github webhook is automatically created if `github_token`, `github_owner` and `github_repo_names` were specified. Read [Add GitHub Webhook](https://github.com/runatlantis/atlantis#add-github-webhook) in the official Atlantis documentation or check [example "GitHub repository webhook for Atlantis"](https://github.com/terraform-aws-modules/terraform-aws-atlantis/tree/master/examples/github-repository-webhook) to add more webhooks.
 
 ### Run Atlantis as a Terraform module
 

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -8,7 +8,7 @@ GitHub's personal access token can be generated at https://github.com/settings/t
 
 ## Usage
 
-To run this code you need to copy `terraform.tfvars.sample` into `terraform.tfvars` and update the values locally or specify them using environment variables (`TF_VAR_github_token=xxx`, `TF_VAR_github_organization=xxx`, etc.). Once ready, execute:
+To run this code you need to copy `terraform.tfvars.sample` into `terraform.tfvars` and update the values locally or specify them using environment variables (`TF_VAR_github_token=xxx`, `TF_VAR_github_owner=xxx`, etc.). Once ready, execute:
 
 ```bash
 $ terraform init
@@ -63,7 +63,7 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 | <a name="input_alb_ingress_cidr_blocks"></a> [alb\_ingress\_cidr\_blocks](#input\_alb\_ingress\_cidr\_blocks) | List of IPv4 CIDR ranges to use on all ingress rules of the ALB - use your personal IP in the form of `x.x.x.x/32` for restricted testing | `list(string)` | n/a | yes |
 | <a name="input_allowed_repo_names"></a> [allowed\_repo\_names](#input\_allowed\_repo\_names) | Repositories that Atlantis will listen for events from and a webhook will be installed | `list(string)` | n/a | yes |
 | <a name="input_domain"></a> [domain](#input\_domain) | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance | `string` | n/a | yes |
-| <a name="input_github_organization"></a> [github\_organization](#input\_github\_organization) | Github organization | `string` | n/a | yes |
+| <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Github owner | `string` | n/a | yes |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token | `string` | n/a | yes |
 | <a name="input_github_user"></a> [github\_user](#input\_github\_user) | Github user for Atlantis to utilize when performing Github activities | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS region where resources will be created | `string` | `"us-east-1"` | no |

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -72,7 +72,7 @@ module "atlantis" {
   # Atlantis
   atlantis_github_user        = var.github_user
   atlantis_github_user_token  = var.github_token
-  atlantis_repo_allowlist     = ["github.com/${var.github_organization}/*"]
+  atlantis_repo_allowlist     = ["github.com/${var.github_owner}/*"]
   atlantis_allowed_repo_names = var.allowed_repo_names
 
   # ALB access
@@ -97,8 +97,8 @@ module "atlantis" {
 module "github_repository_webhook" {
   source = "../../modules/github-repository-webhook"
 
-  github_organization = var.github_organization
-  github_token        = var.github_token
+  github_owner = var.github_owner
+  github_token = var.github_token
 
   atlantis_allowed_repo_names = module.atlantis.atlantis_allowed_repo_names
 

--- a/examples/github-complete/terraform.tfvars.sample
+++ b/examples/github-complete/terraform.tfvars.sample
@@ -1,7 +1,7 @@
 region = "eu-west-1"
 domain = "mydomain.com"
 alb_ingress_cidr_blocks = ["x.x.x.x/32"]
-github_organization = "myorg"
+github_owner = "myaccountowner"
 github_user = "atlantis"
 github_token = "mygithubpersonalaccesstokenforatlantis"
 allowed_repo_names = ["repo1", "repo2"]

--- a/examples/github-complete/variables.tf
+++ b/examples/github-complete/variables.tf
@@ -19,8 +19,8 @@ variable "github_token" {
   type        = string
 }
 
-variable "github_organization" {
-  description = "Github organization"
+variable "github_owner" {
+  description = "Github owner"
   type        = string
 }
 

--- a/examples/github-repository-webhook/README.md
+++ b/examples/github-repository-webhook/README.md
@@ -6,7 +6,7 @@ GitHub's personal access token can be generated at https://github.com/settings/t
 
 ## Usage
 
-To run this code you need to copy `terraform.tfvars.sample` into `terraform.tfvars` and put your GitHub token and Github organization there or specify them using environment variables (`TF_VAR_github_token` and `TF_VAR_github_organization`). Once ready, execute:
+To run this code you need to copy `terraform.tfvars.sample` into `terraform.tfvars` and put your GitHub token and Github owner there or specify them using environment variables (`TF_VAR_github_token` and `TF_VAR_github_owner`). Once ready, execute:
 
 ```bash
 $ terraform init
@@ -47,7 +47,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_github_organization"></a> [github\_organization](#input\_github\_organization) | Github organization | `string` | n/a | yes |
+| <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Github owner | `string` | n/a | yes |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/github-repository-webhook/main.tf
+++ b/examples/github-repository-webhook/main.tf
@@ -11,8 +11,8 @@ module "github_repository_webhook" {
 
   create_github_repository_webhook = true
 
-  github_token        = var.github_token
-  github_organization = var.github_organization
+  github_token = var.github_token
+  github_owner = var.github_owner
 
   # Fetching these attributes from created already Atlantis Terraform state file
   #

--- a/examples/github-repository-webhook/terraform.tfvars.sample
+++ b/examples/github-repository-webhook/terraform.tfvars.sample
@@ -1,2 +1,2 @@
+github_owner = "myusername"
 github_token = "mygithubtoken"
-github_organization = "myusername"

--- a/examples/github-repository-webhook/variables.tf
+++ b/examples/github-repository-webhook/variables.tf
@@ -3,8 +3,8 @@ variable "github_token" {
   type        = string
 }
 
-variable "github_organization" {
-  description = "Github organization"
+variable "github_owner" {
+  description = "Github owner"
   type        = string
 }
 

--- a/modules/github-repository-webhook/README.md
+++ b/modules/github-repository-webhook/README.md
@@ -28,9 +28,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_atlantis_allowed_repo_names"></a> [atlantis\_allowed\_repo\_names](#input\_atlantis\_allowed\_repo\_names) | List of names of repositories which belong to the organization specified in `github_organization` | `list(string)` | n/a | yes |
+| <a name="input_atlantis_allowed_repo_names"></a> [atlantis\_allowed\_repo\_names](#input\_atlantis\_allowed\_repo\_names) | List of names of repositories which belong to the owner specified in `github_owner` | `list(string)` | n/a | yes |
 | <a name="input_create_github_repository_webhook"></a> [create\_github\_repository\_webhook](#input\_create\_github\_repository\_webhook) | Whether to create Github repository webhook for Atlantis | `bool` | `true` | no |
-| <a name="input_github_organization"></a> [github\_organization](#input\_github\_organization) | Github organization to use when creating webhook | `string` | `""` | no |
+| <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Github owner to use when creating webhook | `string` | `""` | no |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token to use when creating webhook | `string` | `""` | no |
 | <a name="input_webhook_secret"></a> [webhook\_secret](#input\_webhook\_secret) | Webhook secret | `string` | `""` | no |
 | <a name="input_webhook_url"></a> [webhook\_url](#input\_webhook\_url) | Webhook URL | `string` | `""` | no |

--- a/modules/github-repository-webhook/main.tf
+++ b/modules/github-repository-webhook/main.tf
@@ -1,6 +1,6 @@
 provider "github" {
-  token        = var.github_token
-  organization = var.github_organization
+  token = var.github_token
+  owner = var.github_owner
 }
 
 resource "github_repository_webhook" "this" {

--- a/modules/github-repository-webhook/variables.tf
+++ b/modules/github-repository-webhook/variables.tf
@@ -10,14 +10,14 @@ variable "github_token" {
   default     = ""
 }
 
-variable "github_organization" {
-  description = "Github organization to use when creating webhook"
+variable "github_owner" {
+  description = "Github owner to use when creating webhook"
   type        = string
   default     = ""
 }
 
 variable "atlantis_allowed_repo_names" {
-  description = "List of names of repositories which belong to the organization specified in `github_organization`"
+  description = "List of names of repositories which belong to the owner specified in `github_owner`"
   type        = list(string)
 }
 


### PR DESCRIPTION
## Description
Rename Organization to Owner for Github components

## Motivation and Context
The GitHub Terraform provider is [deprecating](https://registry.terraform.io/providers/integrations/github/latest/docs#organization) `Organization` as a configuration option, in favour of `Owner`

## Breaking Changes
This requires that the variable name `organization` is renamed to `owner`. It is possible to leave that name unchanged, and just change the reference being passed to the GitHub module, but this is cleaner. 

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
