### PR TITLE
feat: Add an override for a custom ECS Task Role. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ allow_github_webhooks        = true
 | <a name="input_ecs_service_platform_version"></a> [ecs\_service\_platform\_version](#input\_ecs\_service\_platform\_version) | The platform version on which to run your service | `string` | `"LATEST"` | no |
 | <a name="input_ecs_task_cpu"></a> [ecs\_task\_cpu](#input\_ecs\_task\_cpu) | The number of cpu units used by the task | `number` | `256` | no |
 | <a name="input_ecs_task_memory"></a> [ecs\_task\_memory](#input\_ecs\_task\_memory) | The amount (in MiB) of memory used by the task | `number` | `512` | no |
+| <a name="input_ecs_task_role_name"></a> [ecs\_task\_role\_name](#input\_ecs\_task\_role\_name) | Use an existing task role | `string` | `null` | no |
 | <a name="input_enable_ecs_managed_tags"></a> [enable\_ecs\_managed\_tags](#input\_enable\_ecs\_managed\_tags) | Specifies whether to enable Amazon ECS managed tags for the tasks within the service | `bool` | `false` | no |
 | <a name="input_entrypoint"></a> [entrypoint](#input\_entrypoint) | The entry point that is passed to the container | `list(string)` | `null` | no |
 | <a name="input_essential"></a> [essential](#input\_essential) | Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -405,13 +405,13 @@ resource "aws_iam_role" "ecs_task_execution" {
 
 data "aws_iam_role" "custom_ecs_task_role" {
   count = var.ecs_task_role_name == null ? 0 : 1
-  name = var.ecs_task_role_name
+  name  = var.ecs_task_role_name
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
-  count      = var.ecs_task_role_name == null ? length(var.policies_arn) : 0
+  count = var.ecs_task_role_name == null ? length(var.policies_arn) : 0
 
-  role       = aws_iam_role.ecs_task_execution.id
+  role       = aws_iam_role.ecs_task_execution[0].id
   policy_arn = element(var.policies_arn, count.index)
 }
 
@@ -452,7 +452,7 @@ resource "aws_iam_role_policy" "ecs_task_access_secrets" {
 
   name = "ECSTaskAccessSecretsPolicy"
 
-  role = aws_iam_role.ecs_task_execution.id
+  role = aws_iam_role.ecs_task_execution[0].id
 
   policy = element(
     compact(
@@ -580,8 +580,8 @@ module "container_definition_bitbucket" {
 
 resource "aws_ecs_task_definition" "atlantis" {
   family                   = var.name
-  execution_role_arn       = var.ecs_task_role_name == null ? aws_iam_role.ecs_task_execution.arn : data.aws_iam_role.custom_ecs_task_role.arn
-  task_role_arn            = var.ecs_task_role_name == null ? aws_iam_role.ecs_task_execution.arn : data.aws_iam_role.custom_ecs_task_role.arn
+  execution_role_arn       = var.ecs_task_role_name == null ? aws_iam_role.ecs_task_execution[0].arn : data.aws_iam_role.custom_ecs_task_role[0].arn
+  task_role_arn            = var.ecs_task_role_name == null ? aws_iam_role.ecs_task_execution[0].arn : data.aws_iam_role.custom_ecs_task_role[0].arn
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.ecs_task_cpu

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,22 +22,22 @@ output "webhook_secret" {
 # ECS
 output "task_role_arn" {
   description = "The Atlantis ECS task role arn"
-  value       = aws_iam_role.ecs_task_execution.arn
+  value       = var.ecs_task_role_name == null ? aws_iam_role.ecs_task_execution[0].arn : data.aws_iam_role.custom_ecs_task_role[0].arn
 }
 
 output "task_role_id" {
   description = "The Atlantis ECS task role id"
-  value       = aws_iam_role.ecs_task_execution.id
+  value       = var.ecs_task_role_name == null ? aws_iam_role.ecs_task_execution[0].id : data.aws_iam_role.custom_ecs_task_role[0].id
 }
 
 output "task_role_name" {
   description = "The Atlantis ECS task role name"
-  value       = aws_iam_role.ecs_task_execution.name
+  value       = var.ecs_task_role_name == null ? aws_iam_role.ecs_task_execution[0].name : data.aws_iam_role.custom_ecs_task_role[0].name
 }
 
 output "task_role_unique_id" {
   description = "The stable and unique string identifying the Atlantis ECS task role."
-  value       = aws_iam_role.ecs_task_execution.unique_id
+  value       = var.ecs_task_role_name == null ? aws_iam_role.ecs_task_execution[0].unique_id : data.aws_iam_role.custom_ecs_task_role[0].unique_id
 }
 
 output "ecs_task_definition" {

--- a/variables.tf
+++ b/variables.tf
@@ -317,6 +317,12 @@ variable "ecs_task_memory" {
   default     = 512
 }
 
+variable "ecs_task_role_name" {
+  description = "Use an existing task role"
+  type        = string
+  default     = null
+}
+
 variable "container_cpu" {
   description = "The number of cpu units used by the atlantis container. If not specified ecs_task_cpu will be used"
   type        = number


### PR DESCRIPTION
## Description
Add an override for a custom ECS Task Role. 

## Motivation and Context
For anyone running existing AWS infrastructure and have an existing task role for secrets management, it makes sense to use the existing role instead of creating a new one, and having to grant all the secrets again.

## Breaking Changes
No breaking changes, defaults to null and is checked before use.

## How Has This Been Tested?
This is currently in use at Taplytics for our deployment.

