### PR TITLE
feat: Added outputs of ECS and ALB resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,11 +365,19 @@ allow_github_webhooks        = true
 
 | Name | Description |
 |------|-------------|
+| <a name="output_alb_arn"></a> [alb\_arn](#output\_alb\_arn) | ARN of alb |
 | <a name="output_alb_dns_name"></a> [alb\_dns\_name](#output\_alb\_dns\_name) | Dns name of alb |
+| <a name="output_alb_http_listeners_arn"></a> [alb\_http\_listeners\_arn](#output\_alb\_http\_listeners\_arn) | ARNs of alb http listeners |
+| <a name="output_alb_http_listeners_id"></a> [alb\_http\_listeners\_id](#output\_alb\_http\_listeners\_id) | Ids of alb http listeners |
+| <a name="output_alb_https_listeners_arn"></a> [alb\_https\_listeners\_arn](#output\_alb\_https\_listeners\_arn) | ARN of alb https listeners |
+| <a name="output_alb_https_listeners_id"></a> [alb\_https\_listeners\_id](#output\_alb\_https\_listeners\_id) | Ids of alb https listeners |
+| <a name="output_alb_security_group_id"></a> [alb\_security\_group\_id](#output\_alb\_security\_group\_id) | Security group of alb |
 | <a name="output_alb_zone_id"></a> [alb\_zone\_id](#output\_alb\_zone\_id) | Zone ID of alb |
 | <a name="output_atlantis_allowed_repo_names"></a> [atlantis\_allowed\_repo\_names](#output\_atlantis\_allowed\_repo\_names) | Git repositories where webhook should be created |
 | <a name="output_atlantis_url"></a> [atlantis\_url](#output\_atlantis\_url) | URL of Atlantis |
 | <a name="output_atlantis_url_events"></a> [atlantis\_url\_events](#output\_atlantis\_url\_events) | Webhook events URL of Atlantis |
+| <a name="output_ecs_cluster_arn"></a> [ecs\_cluster\_arn](#output\_ecs\_cluster\_arn) | ECS cluster ARN |
+| <a name="output_ecs_cluster_id"></a> [ecs\_cluster\_id](#output\_ecs\_cluster\_id) | ECS cluster id |
 | <a name="output_ecs_security_group"></a> [ecs\_security\_group](#output\_ecs\_security\_group) | Security group assigned to ECS Service in network configuration |
 | <a name="output_ecs_task_definition"></a> [ecs\_task\_definition](#output\_ecs\_task\_definition) | Task definition for ECS service (used for external triggers) |
 | <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | IDs of the VPC private subnets that were created or passed in |

--- a/outputs.tf
+++ b/outputs.tf
@@ -50,6 +50,16 @@ output "ecs_security_group" {
   value       = module.atlantis_sg.this_security_group_id
 }
 
+output "ecs_cluster_id" {
+  description = "ECS cluster id"
+  value       = module.ecs.this_ecs_cluster_id
+}
+
+output "ecs_cluster_arn" {
+  description = "ECS cluster ARN"
+  value       = module.ecs.this_ecs_cluster_arn
+}
+
 # VPC
 output "vpc_id" {
   description = "ID of the VPC that was created or passed in"
@@ -75,4 +85,34 @@ output "alb_dns_name" {
 output "alb_zone_id" {
   description = "Zone ID of alb"
   value       = module.alb.this_lb_zone_id
+}
+
+output "alb_arn" {
+  description = "ARN of alb"
+  value       = module.alb.this_lb_arn
+}
+
+output "alb_sg" {
+  description = "Security group of alb"
+  value       = module.alb_https_sg.this_security_group_id
+}
+
+output "alb_http_listeners_id" {
+  description = "Ids of alb http listeners"
+  value       = module.alb.http_tcp_listener_ids
+}
+
+output "alb_http_listeners_arn" {
+  description = "ARNs of alb http listeners"
+  value       = module.alb.http_tcp_listener_arns
+}
+
+output "alb_https_listeners_id" {
+  description = "Ids of alb https listeners"
+  value       = module.alb.https_listener_ids
+}
+
+output "alb_https_listeners_arn" {
+  description = "ARN of alb https listeners"
+  value       = module.alb.https_listener_arns
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -92,7 +92,7 @@ output "alb_arn" {
   value       = module.alb.this_lb_arn
 }
 
-output "alb_sg" {
+output "alb_security_group_id" {
   description = "Security group of alb"
   value       = module.alb_https_sg.this_security_group_id
 }


### PR DESCRIPTION
## Description
Added alb/ecs/listeners outputs/

## Motivation and Context
Added missing outputs, my motivation is deploy another containers in the same cluster and re-use alb

## Breaking Changes
no

## How Has This Been Tested?

is outputs generate automatically, if yes please point me how to run?
