### PR TITLE
allow mixing IPV4 and IPV6 CIDR blocks for the AWS ALB

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -298,7 +298,8 @@ module "alb_http_sg" {
   vpc_id      = local.vpc_id
   description = "Security group with HTTP ports open for specific IPv4 and IPv6CIDR block (or everybody), egress ports are all world open"
 
-  ingress_cidr_blocks = sort(compact(concat(var.allow_github_webhooks ? var.github_webhooks_cidr_blocks : [], var.alb_ingress_cidr_blocks)))
+  ingress_cidr_blocks = local.alb_ingress_ipv4_cidr_blocks
+  ingress_ipv6_cidr_blocks = local.alb_ingress_ipv6_cidr_blocks
 
   tags = merge(local.tags, var.alb_http_security_group_tags)
 }

--- a/main.tf
+++ b/main.tf
@@ -282,7 +282,7 @@ module "alb_https_sg" {
 
   name        = "${var.name}-alb-https"
   vpc_id      = local.vpc_id
-  description = "Security group with HTTPS ports open for specific IPv4 CIDR block (or everybody), egress ports are all world open"
+  description = "Security group with HTTPS ports open for specific IPv4 and IPv6 CIDR block (or everybody), egress ports are all world open"
 
   ingress_cidr_blocks = local.alb_ingress_ipv4_cidr_blocks
   ingress_ipv6_cidr_blocks = local.alb_ingress_ipv6_cidr_blocks
@@ -296,7 +296,7 @@ module "alb_http_sg" {
 
   name        = "${var.name}-alb-http"
   vpc_id      = local.vpc_id
-  description = "Security group with HTTP ports open for specific IPv4 CIDR block (or everybody), egress ports are all world open"
+  description = "Security group with HTTP ports open for specific IPv4 and IPv6CIDR block (or everybody), egress ports are all world open"
 
   ingress_cidr_blocks = sort(compact(concat(var.allow_github_webhooks ? var.github_webhooks_cidr_blocks : [], var.alb_ingress_cidr_blocks)))
 


### PR DESCRIPTION
### Description

Allow mixing IPV4 and IPV6 CIDR blocks for the AWS ALB.

### Motivation and Context

Github started using IPv6 addresses.

If Atlantis is configured to allow GitHub IPs (via `alb_ingress_cidr_blocks` using "github" provider), terraform would fail with the following error:

``` 
Error: Error authorizing security group rule type ingress: InvalidParameterValue: CIDR block 2606:50c0::/32 is malformed
```

### Breaking Changes

No breaking changes.

### How Has This Been Tested?

Tested manually using mixed range of IPv6 and IPv4 addresses.