### PR TITLE
BREAKING CHANGE: update internal modules to latest, replace `github_organization` with `github_owner`, bump Terraform version to >=0.13.1

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.13.0/terraform-docs-v0.13.0-$(uname)-amd64.tar.gz && tar -xzf terraform-docs.tar.gz && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.13.0/terraform-docs-v0.13.0-$(uname)-amd64.tar.gz && tar -xzf terraform-docs.tar.gz terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ cd terraform-aws-atlantis
 
 5. Run `terraform output atlantis_url` to get URL where Atlantis is publicly reachable. (Note: It may take a minute or two to get it reachable for the first time)
 
-6. Github webhook is automatically created if `github_token`, `github_organization` and `github_repo_names` were specified. Read [Add GitHub Webhook](https://github.com/runatlantis/atlantis#add-github-webhook) in the official Atlantis documentation or check [example "GitHub repository webhook for Atlantis"](https://github.com/terraform-aws-modules/terraform-aws-atlantis/tree/master/examples/github-repository-webhook) to add more webhooks.
+6. Github webhook is automatically created if `github_token`, `github_owner` and `github_repo_names` were specified. Read [Add GitHub Webhook](https://github.com/runatlantis/atlantis#add-github-webhook) in the official Atlantis documentation or check [example "GitHub repository webhook for Atlantis"](https://github.com/terraform-aws-modules/terraform-aws-atlantis/tree/master/examples/github-repository-webhook) to add more webhooks.
 
 ### Run Atlantis as a Terraform module
 
@@ -55,7 +55,7 @@ This way allows integration with your existing Terraform configurations.
 ```hcl
 module "atlantis" {
   source  = "terraform-aws-modules/atlantis/aws"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   name = "atlantis"
 
@@ -209,7 +209,7 @@ allow_github_webhooks        = true
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
@@ -224,15 +224,15 @@ allow_github_webhooks        = true
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | v2.12.0 |
-| <a name="module_alb"></a> [alb](#module\_alb) | terraform-aws-modules/alb/aws | v5.10.0 |
-| <a name="module_alb_http_sg"></a> [alb\_http\_sg](#module\_alb\_http\_sg) | terraform-aws-modules/security-group/aws//modules/http-80 | v3.17.0 |
-| <a name="module_alb_https_sg"></a> [alb\_https\_sg](#module\_alb\_https\_sg) | terraform-aws-modules/security-group/aws//modules/https-443 | v3.17.0 |
-| <a name="module_atlantis_sg"></a> [atlantis\_sg](#module\_atlantis\_sg) | terraform-aws-modules/security-group/aws | v3.17.0 |
-| <a name="module_container_definition_bitbucket"></a> [container\_definition\_bitbucket](#module\_container\_definition\_bitbucket) | cloudposse/ecs-container-definition/aws | v0.45.2 |
-| <a name="module_container_definition_github_gitlab"></a> [container\_definition\_github\_gitlab](#module\_container\_definition\_github\_gitlab) | cloudposse/ecs-container-definition/aws | v0.45.2 |
-| <a name="module_ecs"></a> [ecs](#module\_ecs) | terraform-aws-modules/ecs/aws | v2.5.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | v2.64.0 |
+| <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | v3.2.0 |
+| <a name="module_alb"></a> [alb](#module\_alb) | terraform-aws-modules/alb/aws | v6.5.0 |
+| <a name="module_alb_http_sg"></a> [alb\_http\_sg](#module\_alb\_http\_sg) | terraform-aws-modules/security-group/aws//modules/http-80 | v4.3.0 |
+| <a name="module_alb_https_sg"></a> [alb\_https\_sg](#module\_alb\_https\_sg) | terraform-aws-modules/security-group/aws//modules/https-443 | v4.3.0 |
+| <a name="module_atlantis_sg"></a> [atlantis\_sg](#module\_atlantis\_sg) | terraform-aws-modules/security-group/aws | v4.3.0 |
+| <a name="module_container_definition_bitbucket"></a> [container\_definition\_bitbucket](#module\_container\_definition\_bitbucket) | cloudposse/ecs-container-definition/aws | v0.58.1 |
+| <a name="module_container_definition_github_gitlab"></a> [container\_definition\_github\_gitlab](#module\_container\_definition\_github\_gitlab) | cloudposse/ecs-container-definition/aws | v0.58.1 |
+| <a name="module_ecs"></a> [ecs](#module\_ecs) | terraform-aws-modules/ecs/aws | v3.3.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | v3.6.0 |
 
 ## Resources
 
@@ -255,6 +255,7 @@ allow_github_webhooks        = true
 | [aws_iam_policy_document.ecs_task_access_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ecs_task_access_secrets_with_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ecs_tasks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 
@@ -335,7 +336,7 @@ allow_github_webhooks        = true
 | <a name="input_mount_points"></a> [mount\_points](#input\_mount\_points) | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume`. The `readOnly` key is optional. | `list(any)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to use on all resources created (VPC, ALB, etc) | `string` | `"atlantis"` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | If provided, all IAM roles will be created with this permissions boundary attached. | `string` | `null` | no |
-| <a name="input_policies_arn"></a> [policies\_arn](#input\_policies\_arn) | A list of the ARN of the policies you want to apply | `list(string)` | <pre>[<br>  "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"<br>]</pre> | no |
+| <a name="input_policies_arn"></a> [policies\_arn](#input\_policies\_arn) | A list of the ARN of the policies you want to apply | `list(string)` | `null` | no |
 | <a name="input_private_subnet_ids"></a> [private\_subnet\_ids](#input\_private\_subnet\_ids) | A list of IDs of existing private subnets inside the VPC | `list(string)` | `[]` | no |
 | <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | A list of private subnets inside the VPC | `list(string)` | `[]` | no |
 | <a name="input_propagate_tags"></a> [propagate\_tags](#input\_propagate\_tags) | Specifies whether to propagate the tags from the task definition or the service to the tasks. The valid values are SERVICE and TASK\_DEFINITION | `string` | `null` | no |

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -8,7 +8,7 @@ GitHub's personal access token can be generated at https://github.com/settings/t
 
 ## Usage
 
-To run this code you need to copy `terraform.tfvars.sample` into `terraform.tfvars` and update the values locally or specify them using environment variables (`TF_VAR_github_token=xxx`, `TF_VAR_github_organization=xxx`, etc.). Once ready, execute:
+To run this code you need to copy `terraform.tfvars.sample` into `terraform.tfvars` and update the values locally or specify them using environment variables (`TF_VAR_github_token=xxx`, `TF_VAR_github_owner=xxx`, etc.). Once ready, execute:
 
 ```bash
 $ terraform init
@@ -29,9 +29,9 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | >= 2.4.1 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 4.8 |
 
 ## Providers
 
@@ -44,7 +44,7 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_atlantis"></a> [atlantis](#module\_atlantis) | ../../ |  |
-| <a name="module_atlantis_access_log_bucket"></a> [atlantis\_access\_log\_bucket](#module\_atlantis\_access\_log\_bucket) | terraform-aws-modules/s3-bucket/aws | >= 1.9 |
+| <a name="module_atlantis_access_log_bucket"></a> [atlantis\_access\_log\_bucket](#module\_atlantis\_access\_log\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 2 |
 | <a name="module_github_repository_webhook"></a> [github\_repository\_webhook](#module\_github\_repository\_webhook) | ../../modules/github-repository-webhook |  |
 
 ## Resources
@@ -63,12 +63,9 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 | <a name="input_alb_ingress_cidr_blocks"></a> [alb\_ingress\_cidr\_blocks](#input\_alb\_ingress\_cidr\_blocks) | List of IPv4 CIDR ranges to use on all ingress rules of the ALB - use your personal IP in the form of `x.x.x.x/32` for restricted testing | `list(string)` | n/a | yes |
 | <a name="input_allowed_repo_names"></a> [allowed\_repo\_names](#input\_allowed\_repo\_names) | Repositories that Atlantis will listen for events from and a webhook will be installed | `list(string)` | n/a | yes |
 | <a name="input_domain"></a> [domain](#input\_domain) | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance | `string` | n/a | yes |
-| <a name="input_github_organization"></a> [github\_organization](#input\_github\_organization) | Github organization | `string` | n/a | yes |
+| <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Github owner | `string` | n/a | yes |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token | `string` | n/a | yes |
 | <a name="input_github_user"></a> [github\_user](#input\_github\_user) | Github user for Atlantis to utilize when performing Github activities | `string` | n/a | yes |
-| <a name="input_region"></a> [region](#input\_region) | AWS region where resources will be created | `string` | `"us-east-1"` | no |
-| <a name="input_trusted_entities"></a> [trusted\_entities](#input\_trusted\_entities) | A list of  users or roles, that can assume the task role | `list(string)` | `[]` | no |
-| <a name="input_trusted_principals"></a> [trusted\_principals](#input\_trusted\_principals) | A list of principals, in addition to ecs-tasks.amazonaws.com, that can assume the task role | `list(string)` | n/a | yes |
 
 ## Outputs
 

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -68,6 +68,9 @@ module "atlantis" {
   # DNS
   route53_zone_name = var.domain
 
+  # Trusted roles
+  trusted_principals = ["ssm.amazonaws.com"]
+
   # Atlantis
   atlantis_github_user        = var.github_user
   atlantis_github_user_token  = var.github_token

--- a/examples/github-complete/outputs.tf
+++ b/examples/github-complete/outputs.tf
@@ -22,10 +22,10 @@ output "ecs_task_definition" {
 # Webhooks
 output "github_webhook_urls" {
   description = "Github webhook URL"
-  value       = module.github_repository_webhook.this_repository_webhook_urls
+  value       = module.github_repository_webhook.repository_webhook_urls
 }
 
 output "github_webhook_secret" {
   description = "Github webhook secret"
-  value       = module.github_repository_webhook.this_repository_webhook_secret
+  value       = module.github_repository_webhook.repository_webhook_secret
 }

--- a/examples/github-complete/terraform.tfvars.sample
+++ b/examples/github-complete/terraform.tfvars.sample
@@ -1,8 +1,6 @@
-region = "eu-west-1"
 domain = "mydomain.com"
 alb_ingress_cidr_blocks = ["x.x.x.x/32"]
-github_organization = "myorg"
+github_owner = "myorg"
 github_user = "atlantis"
 github_token = "mygithubpersonalaccesstokenforatlantis"
 allowed_repo_names = ["repo1", "repo2"]
-trusted_principals = ["ssm.amazonaws.com"] # Convenient if you want to enable SSM access into Atlantis for troubleshooting etc

--- a/examples/github-complete/variables.tf
+++ b/examples/github-complete/variables.tf
@@ -1,9 +1,3 @@
-variable "region" {
-  description = "AWS region where resources will be created"
-  type        = string
-  default     = "us-east-1"
-}
-
 variable "domain" {
   description = "Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance"
   type        = string
@@ -19,8 +13,8 @@ variable "github_token" {
   type        = string
 }
 
-variable "github_organization" {
-  description = "Github organization"
+variable "github_owner" {
+  description = "Github owner"
   type        = string
 }
 
@@ -32,15 +26,4 @@ variable "github_user" {
 variable "allowed_repo_names" {
   description = "Repositories that Atlantis will listen for events from and a webhook will be installed"
   type        = list(string)
-}
-
-variable "trusted_principals" {
-  description = "A list of principals, in addition to ecs-tasks.amazonaws.com, that can assume the task role"
-  type        = list(string)
-}
-
-variable "trusted_entities" {
-  description = "A list of  users or roles, that can assume the task role"
-  type        = list(string)
-  default     = []
 }

--- a/examples/github-complete/versions.tf
+++ b/examples/github-complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws = {
@@ -9,7 +9,7 @@ terraform {
 
     github = {
       source  = "integrations/github"
-      version = ">= 2.4.1"
+      version = ">= 4.8"
     }
   }
 }

--- a/examples/github-repository-webhook/README.md
+++ b/examples/github-repository-webhook/README.md
@@ -1,12 +1,12 @@
 # GitHub repository webhook for Atlantis
 
-Configuration in this directory creates GitHub repository webhooks configured to Atlantis URL. This example uses value of webhook secret which got generated when Atlantis setup by referring to `terraform.tfstate`, so this example has to run after Atlantis. 
+Configuration in this directory creates GitHub repository webhooks configured to Atlantis URL. This example uses value of webhook secret which got generated when Atlantis setup by referring to `terraform.tfstate`, so this example has to run after Atlantis.
 
-GitHub's personal access token can be generated at https://github.com/settings/tokens 
+GitHub's personal access token can be generated at https://github.com/settings/tokens
 
 ## Usage
 
-To run this code you need to copy `terraform.tfvars.sample` into `terraform.tfvars` and put your GitHub token and Github organization there or specify them using environment variables (`TF_VAR_github_token` and `TF_VAR_github_organization`). Once ready, execute:
+To run this code you need to copy `terraform.tfvars.sample` into `terraform.tfvars` and put your GitHub token and Github owner there or specify them using environment variables (`TF_VAR_github_token` and `TF_VAR_github_owner`). Once ready, execute:
 
 ```bash
 $ terraform init
@@ -21,9 +21,9 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | >= 2.4.1 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 4.8 |
 
 ## Providers
 
@@ -47,7 +47,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_github_organization"></a> [github\_organization](#input\_github\_organization) | Github organization | `string` | n/a | yes |
+| <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Github owner | `string` | n/a | yes |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/github-repository-webhook/main.tf
+++ b/examples/github-repository-webhook/main.tf
@@ -2,7 +2,7 @@ data "terraform_remote_state" "atlantis" {
   backend = "local"
 
   config = {
-    path = "../../terraform.tfstate"
+    path = "../github-complete/terraform.tfstate"
   }
 }
 
@@ -11,8 +11,8 @@ module "github_repository_webhook" {
 
   create_github_repository_webhook = true
 
-  github_token        = var.github_token
-  github_organization = var.github_organization
+  github_token = var.github_token
+  github_owner = var.github_owner
 
   # Fetching these attributes from created already Atlantis Terraform state file
   #
@@ -20,6 +20,6 @@ module "github_repository_webhook" {
   # https://github.com/mygithubusername/awesome-repo and https://github.com/mygithubusername/another-awesome-repo
   atlantis_allowed_repo_names = data.terraform_remote_state.atlantis.outputs.atlantis_allowed_repo_names
 
-  webhook_url    = data.terraform_remote_state.atlantis.outputs.atlantis_url_events
-  webhook_secret = data.terraform_remote_state.atlantis.outputs.webhook_secret
+  webhook_url    = element(data.terraform_remote_state.atlantis.outputs.github_webhook_urls, 0)
+  webhook_secret = data.terraform_remote_state.atlantis.outputs.github_webhook_secret
 }

--- a/examples/github-repository-webhook/outputs.tf
+++ b/examples/github-repository-webhook/outputs.tf
@@ -1,9 +1,9 @@
 output "github_webhook_urls" {
   description = "Github webhook URL"
-  value       = module.github_repository_webhook.this_repository_webhook_urls
+  value       = module.github_repository_webhook.repository_webhook_urls
 }
 
 output "github_webhook_secret" {
   description = "Github webhook secret"
-  value       = module.github_repository_webhook.this_repository_webhook_secret
+  value       = module.github_repository_webhook.repository_webhook_secret
 }

--- a/examples/github-repository-webhook/terraform.tfvars.sample
+++ b/examples/github-repository-webhook/terraform.tfvars.sample
@@ -1,2 +1,2 @@
 github_token = "mygithubtoken"
-github_organization = "myusername"
+github_owner = "myusername"

--- a/examples/github-repository-webhook/variables.tf
+++ b/examples/github-repository-webhook/variables.tf
@@ -3,8 +3,8 @@ variable "github_token" {
   type        = string
 }
 
-variable "github_organization" {
-  description = "Github organization"
+variable "github_owner" {
+  description = "Github owner"
   type        = string
 }
 

--- a/examples/github-repository-webhook/versions.tf
+++ b/examples/github-repository-webhook/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws = {
@@ -9,7 +9,7 @@ terraform {
 
     github = {
       source  = "integrations/github"
-      version = ">= 2.4.1"
+      version = ">= 4.8"
     }
   }
 }

--- a/examples/gitlab-repository-webhook/README.md
+++ b/examples/gitlab-repository-webhook/README.md
@@ -1,10 +1,10 @@
 # Gitlab repository webhook for Atlantis
 
-Configuration in this directory creates Gitlab repository webhooks configured to Atlantis URL. This example uses value of webhook secret which got generated when Atlantis setup by referring to `terraform.tfstate`, so this example has to run after Atlantis. 
+Configuration in this directory creates Gitlab repository webhooks configured to Atlantis URL. This example uses value of webhook secret which got generated when Atlantis setup by referring to `terraform.tfstate`, so this example has to run after Atlantis.
 
 ## Usage
 
-To run this code you need to copy `terraform.tfvars.sample` into `terraform.tfvars` and put your GitHub token and Github organization there or specify them using environment variables (`TF_VAR_gitlab_token` and `TF_VAR_gitlab_base_url`). Once ready, execute:
+To run this code you need to copy `terraform.tfvars.sample` into `terraform.tfvars` and put your GitHub token and Github owner there or specify them using environment variables (`TF_VAR_gitlab_token` and `TF_VAR_gitlab_base_url`). Once ready, execute:
 
 ```bash
 $ terraform init
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
 | <a name="requirement_gitlab"></a> [gitlab](#requirement\_gitlab) | >= 3.0 |
 

--- a/examples/gitlab-repository-webhook/outputs.tf
+++ b/examples/gitlab-repository-webhook/outputs.tf
@@ -1,9 +1,9 @@
 output "gitlab_webhook_urls" {
   description = "Gitlab webhook URL"
-  value       = module.gitlab_repository_webhook.this_repository_webhook_urls
+  value       = module.gitlab_repository_webhook.repository_webhook_urls
 }
 
 output "gitlab_webhook_secret" {
   description = "Gitlab webhook secret"
-  value       = module.gitlab_repository_webhook.this_repository_webhook_secret
+  value       = module.gitlab_repository_webhook.repository_webhook_secret
 }

--- a/examples/gitlab-repository-webhook/versions.tf
+++ b/examples/gitlab-repository-webhook/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws = {

--- a/modules/github-repository-webhook/README.md
+++ b/modules/github-repository-webhook/README.md
@@ -5,14 +5,14 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | >= 2.4.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 4.8 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | >= 2.4.1 |
+| <a name="provider_github"></a> [github](#provider\_github) | >= 4.8 |
 
 ## Modules
 
@@ -28,9 +28,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_atlantis_allowed_repo_names"></a> [atlantis\_allowed\_repo\_names](#input\_atlantis\_allowed\_repo\_names) | List of names of repositories which belong to the organization specified in `github_organization` | `list(string)` | n/a | yes |
+| <a name="input_atlantis_allowed_repo_names"></a> [atlantis\_allowed\_repo\_names](#input\_atlantis\_allowed\_repo\_names) | List of names of repositories which belong to the owner specified in `github_owner` | `list(string)` | n/a | yes |
 | <a name="input_create_github_repository_webhook"></a> [create\_github\_repository\_webhook](#input\_create\_github\_repository\_webhook) | Whether to create Github repository webhook for Atlantis | `bool` | `true` | no |
-| <a name="input_github_organization"></a> [github\_organization](#input\_github\_organization) | Github organization to use when creating webhook | `string` | `""` | no |
+| <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Github owner to use when creating webhook | `string` | `""` | no |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token to use when creating webhook | `string` | `""` | no |
 | <a name="input_webhook_secret"></a> [webhook\_secret](#input\_webhook\_secret) | Webhook secret | `string` | `""` | no |
 | <a name="input_webhook_url"></a> [webhook\_url](#input\_webhook\_url) | Webhook URL | `string` | `""` | no |
@@ -39,6 +39,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_this_repository_webhook_secret"></a> [this\_repository\_webhook\_secret](#output\_this\_repository\_webhook\_secret) | Webhook secret |
-| <a name="output_this_repository_webhook_urls"></a> [this\_repository\_webhook\_urls](#output\_this\_repository\_webhook\_urls) | Webhook URL |
+| <a name="output_repository_webhook_secret"></a> [repository\_webhook\_secret](#output\_repository\_webhook\_secret) | Webhook secret |
+| <a name="output_repository_webhook_urls"></a> [repository\_webhook\_urls](#output\_repository\_webhook\_urls) | Webhook URL |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/github-repository-webhook/main.tf
+++ b/modules/github-repository-webhook/main.tf
@@ -1,6 +1,6 @@
 provider "github" {
-  token        = var.github_token
-  organization = var.github_organization
+  token = var.github_token
+  owner = var.github_owner
 }
 
 resource "github_repository_webhook" "this" {

--- a/modules/github-repository-webhook/outputs.tf
+++ b/modules/github-repository-webhook/outputs.tf
@@ -1,9 +1,9 @@
-output "this_repository_webhook_urls" {
+output "repository_webhook_urls" {
   description = "Webhook URL"
   value       = github_repository_webhook.this.*.url
 }
 
-output "this_repository_webhook_secret" {
+output "repository_webhook_secret" {
   description = "Webhook secret"
   value       = var.webhook_secret
 }

--- a/modules/github-repository-webhook/variables.tf
+++ b/modules/github-repository-webhook/variables.tf
@@ -10,14 +10,14 @@ variable "github_token" {
   default     = ""
 }
 
-variable "github_organization" {
-  description = "Github organization to use when creating webhook"
+variable "github_owner" {
+  description = "Github owner to use when creating webhook"
   type        = string
   default     = ""
 }
 
 variable "atlantis_allowed_repo_names" {
-  description = "List of names of repositories which belong to the organization specified in `github_organization`"
+  description = "List of names of repositories which belong to the owner specified in `github_owner`"
   type        = list(string)
 }
 

--- a/modules/github-repository-webhook/versions.tf
+++ b/modules/github-repository-webhook/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.1"
 
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 2.4.1"
+      version = ">= 4.8"
     }
   }
 }

--- a/modules/gitlab-repository-webhook/README.md
+++ b/modules/gitlab-repository-webhook/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_gitlab"></a> [gitlab](#requirement\_gitlab) | >= 3.0 |
 
 ## Providers
@@ -28,7 +28,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_atlantis_allowed_repo_names"></a> [atlantis\_allowed\_repo\_names](#input\_atlantis\_allowed\_repo\_names) | List of names of repositories which belong to the organization specified in `gitlab_organization` | `list(string)` | n/a | yes |
+| <a name="input_atlantis_allowed_repo_names"></a> [atlantis\_allowed\_repo\_names](#input\_atlantis\_allowed\_repo\_names) | List of names of repositories which belong to the `gitlab_base_url` specified | `list(string)` | n/a | yes |
 | <a name="input_create_gitlab_repository_webhook"></a> [create\_gitlab\_repository\_webhook](#input\_create\_gitlab\_repository\_webhook) | Whether to create Gitlab repository webhook for Atlantis | `bool` | `true` | no |
 | <a name="input_gitlab_base_url"></a> [gitlab\_base\_url](#input\_gitlab\_base\_url) | Gitlab base\_url use | `string` | `""` | no |
 | <a name="input_gitlab_token"></a> [gitlab\_token](#input\_gitlab\_token) | Gitlab token to use when creating webhook | `string` | `""` | no |
@@ -39,6 +39,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_this_repository_webhook_secret"></a> [this\_repository\_webhook\_secret](#output\_this\_repository\_webhook\_secret) | Webhook secret |
-| <a name="output_this_repository_webhook_urls"></a> [this\_repository\_webhook\_urls](#output\_this\_repository\_webhook\_urls) | Webhook URL |
+| <a name="output_repository_webhook_secret"></a> [repository\_webhook\_secret](#output\_repository\_webhook\_secret) | Webhook secret |
+| <a name="output_repository_webhook_urls"></a> [repository\_webhook\_urls](#output\_repository\_webhook\_urls) | Webhook URL |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/gitlab-repository-webhook/outputs.tf
+++ b/modules/gitlab-repository-webhook/outputs.tf
@@ -1,9 +1,9 @@
-output "this_repository_webhook_urls" {
+output "repository_webhook_urls" {
   description = "Webhook URL"
   value       = gitlab_project_hook.this.*.url
 }
 
-output "this_repository_webhook_secret" {
+output "repository_webhook_secret" {
   description = "Webhook secret"
   value       = var.webhook_secret
 }

--- a/modules/gitlab-repository-webhook/variables.tf
+++ b/modules/gitlab-repository-webhook/variables.tf
@@ -17,7 +17,7 @@ variable "gitlab_token" {
 }
 
 variable "atlantis_allowed_repo_names" {
-  description = "List of names of repositories which belong to the organization specified in `gitlab_organization`"
+  description = "List of names of repositories which belong to the `gitlab_base_url` specified"
   type        = list(string)
 }
 

--- a/modules/gitlab-repository-webhook/versions.tf
+++ b/modules/gitlab-repository-webhook/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 
   required_providers {
     gitlab = {

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,17 +47,17 @@ output "ecs_task_definition" {
 
 output "ecs_security_group" {
   description = "Security group assigned to ECS Service in network configuration"
-  value       = module.atlantis_sg.this_security_group_id
+  value       = module.atlantis_sg.security_group_id
 }
 
 output "ecs_cluster_id" {
   description = "ECS cluster id"
-  value       = module.ecs.this_ecs_cluster_id
+  value       = module.ecs.ecs_cluster_id
 }
 
 output "ecs_cluster_arn" {
   description = "ECS cluster ARN"
-  value       = module.ecs.this_ecs_cluster_arn
+  value       = module.ecs.ecs_cluster_arn
 }
 
 # VPC
@@ -79,22 +79,22 @@ output "public_subnet_ids" {
 # ALB
 output "alb_dns_name" {
   description = "Dns name of alb"
-  value       = module.alb.this_lb_dns_name
+  value       = module.alb.lb_dns_name
 }
 
 output "alb_zone_id" {
   description = "Zone ID of alb"
-  value       = module.alb.this_lb_zone_id
+  value       = module.alb.lb_zone_id
 }
 
 output "alb_arn" {
   description = "ARN of alb"
-  value       = module.alb.this_lb_arn
+  value       = module.alb.lb_arn
 }
 
 output "alb_security_group_id" {
   description = "Security group of alb"
-  value       = module.alb_https_sg.this_security_group_id
+  value       = module.alb_https_sg.security_group_id
 }
 
 output "alb_http_listeners_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -254,7 +254,7 @@ variable "permissions_boundary" {
 variable "policies_arn" {
   description = "A list of the ARN of the policies you want to apply"
   type        = list(string)
-  default     = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
+  default     = null
 }
 
 variable "trusted_principals" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Description
- add data source for using correct partition based on where Atlantis is provisioned for the default ECS task execution policy ARN
- update sub-modules to use latest versions; GitHub version need to be updated for deprecating changes
- bump min Terraform version to 0.13.1+ due to module and provider support
- replace `github_organization` with `github_owner` due to deprecation in the GitHub provider
- switch policy ARN attachment from `count` to `for_each` 
- correct `github-complete` example project so it works correctly again (trusted principals and trusted entities)

## Motivation and Context
Closes #190
Closes #192
Closes #201

## Breaking Changes
- Yes; support for Terraform v0.12.x is dropped, and GitHub provider min version supported raised to v4.8.x for deprecation of `github_organization`

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	- complete example updated and validated with test projects 
	- also fixed/updated GitHub webhook example project