### PR TITLE
feat: update default image to ghcr.io one

### DIFF
--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -52,7 +52,7 @@ module "atlantis" {
   docker_labels = {
     "org.opencontainers.image.title"       = "Atlantis"
     "org.opencontainers.image.description" = "A self-hosted golang application that listens for Terraform pull request events via webhooks."
-    "org.opencontainers.image.url"         = "https://github.com/runatlantis/atlantis/blob/master/Dockerfile"
+    "org.opencontainers.image.url"         = "https://github.com/runatlantis/atlantis/pkgs/container/atlantis"
   }
   start_timeout = 30
   stop_timeout  = 30

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
   public_subnet_ids  = coalescelist(module.vpc.public_subnets, var.public_subnet_ids, [""])
 
   # Atlantis
-  atlantis_image = var.atlantis_image == "" ? "runatlantis/atlantis:${var.atlantis_version}" : var.atlantis_image
+  atlantis_image = var.atlantis_image == "" ? "ghcr.io/runatlantis/atlantis:${var.atlantis_version}" : var.atlantis_image
   atlantis_url = "https://${coalesce(
     var.atlantis_fqdn,
     element(concat(aws_route53_record.atlantis.*.fqdn, [""]), 0),


### PR DESCRIPTION
## Description
per [Atlantis 0.17.1 release](https://github.com/runatlantis/atlantis/releases/tag/v0.17.1), the default image registry is ghcr.io. Thus updating the code to reflect that.

