### PR TITLE
fix: correct semantic-release message that is causing releases to fail

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.56.0
+    rev: v1.57.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,7 +10,8 @@
     [
       "@semantic-release/github",
       {
-        "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version [${nextRelease.version}](${releaseInfos[0].url}) :tada:",
+        "successComment":
+        "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version} :tada:",
         "labels": false,
         "releasedLabels": false
       }


### PR DESCRIPTION
## Description
- correct semantic-release message that is causing releases to fail

## Motivation and Context
- Correct the release configuration template so that releases do not fail https://github.com/terraform-aws-modules/terraform-aws-atlantis/pull/237#issuecomment-973931742

## Breaking Changes
- No

## How Has This Been Tested?
- N/A - no source code change 
