### PR TITLE
fix: atlantis health check path

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -246,6 +246,9 @@ module "alb" {
       backend_port         = var.atlantis_port
       target_type          = "ip"
       deregistration_delay = 10
+      health_check = {
+        path = "/healthz"
+      }
     },
   ]
 


### PR DESCRIPTION
## Description

Update health check path for Atlantis.

## Motivation and Context

* https://github.com/runatlantis/atlantis/pull/144

Atlantis has the `/healthz` endpoint for health checks. This endpoint should be used for health checks from ALB. 

For example, if Atlantis BASIC authentication is enabled, this endpoint is the only path that does not require authentication.

* https://github.com/runatlantis/atlantis/pull/1896

## Breaking Changes

<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
