### PR TITLE
chore: Update release configs based on EKS findings

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,52 @@
+name: "Validate PR title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      # Please look up the latest version from
+      # https://github.com/amannn/action-semantic-pull-request/releases
+      - uses: amannn/action-semantic-pull-request@v3.4.6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which types are allowed.
+          # Default: https://github.com/commitizen/conventional-commit-types
+          types: |
+            fix
+            feat
+            docs
+            ci
+            chore
+          # Configure that a scope must always be provided.
+          requireScope: false
+          # Configure additional validation for the subject based on a regex.
+          # This example ensures the subject starts with an uppercase character.
+          subjectPattern: ^[A-Z].+$
+          # If `subjectPattern` is configured, you can use this property to override
+          # the default error message that is shown when the pattern doesn't match.
+          # The variables `subject` and `title` can be used within the message.
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            starts with an uppercase character.
+          # For work-in-progress PRs you can typically use draft pull requests
+          # from Github. However, private repositories on the free plan don't have
+          # this option and therefore this action allows you to opt-in to using the
+          # special "[WIP]" prefix to indicate this state. This will avoid the
+          # validation of the PR title and the pull request checks remain pending.
+          # Note that a second check will be reported if this is enabled.
+          wip: true
+          # When using "Squash and merge" on a PR with only one commit, GitHub
+          # will suggest using that commit message instead of the PR title for the
+          # merge commit, and it's easy to commit this by mistake. Enable this option
+          # to also validate the commit message for one commit PRs.
+          validateSingleCommit: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,10 @@ on:
       - main
       - master
     paths:
+      - '**/*.tpl'
       - '**/*.py'
       - '**/*.tf'
+      - '.github/workflows/release.yml'
 
 jobs:
   release:
@@ -28,5 +30,6 @@ jobs:
           extra_plugins: |
             @semantic-release/changelog@6.0.0
             @semantic-release/git@10.0.0
+            conventional-changelog-conventionalcommits@4.6.3
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}

--- a/.github/workflows/stale-actions.yaml
+++ b/.github/workflows/stale-actions.yaml
@@ -1,0 +1,32 @@
+name: "Mark or close stale issues and PRs"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v4
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Staling issues and PR's
+        days-before-stale: 30
+        stale-issue-label: stale
+        stale-pr-label: stale
+        stale-issue-message: |
+          This issue has been automatically marked as stale because it has been open 30 days
+          with no activity. Remove stale label or comment or this issue will be closed in 10 days
+        stale-pr-message: |
+          This PR has been automatically marked as stale because it has been open 30 days
+          with no activity. Remove stale label or comment or this PR will be closed in 10 days
+        # Not stale if have this labels or part of milestone
+        exempt-issue-labels: bug,wip,on-hold
+        exempt-pr-labels:    bug,wip,on-hold
+        exempt-all-milestones: true
+        # Close issue operations
+        # Label will be automatically removed if the issues are no longer closed nor locked.
+        days-before-close: 10
+        delete-branch: true
+        close-issue-message: This issue was automatically closed because of stale in 10 days
+        close-pr-message: This PR was automatically closed because of stale in 10 days

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.58.0
+    rev: v1.62.3
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,6 +23,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
       - id: check-merge-conflict

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,13 +5,22 @@
   ],
   "ci": false,
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
     [
       "@semantic-release/github",
       {
-        "successComment":
-        "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version} :tada:",
+        "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version} :tada:",
         "labels": false,
         "releasedLabels": false
       }

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,7 +16,7 @@ output "atlantis_allowed_repo_names" {
 
 output "webhook_secret" {
   description = "Webhook secret"
-  value       = element(concat(random_id.webhook.*.hex, [""]), 0)
+  value       = try(random_id.webhook[0].hex, "")
   sensitive   = true
 }
 


### PR DESCRIPTION
## Description
- update release configs based on EKS findings
- add PR title check and stale issue workflows from EKS module

## Motivation and Context
- current configurations do not respect conventional commit conventions; this fixes that

## Breaking Changes
- No

## How Has This Been Tested?
- N/A
