### PR TITLE
feat: Add base URL for GitHub Enterprise

### DIFF
--- a/modules/github-repository-webhook/README.md
+++ b/modules/github-repository-webhook/README.md
@@ -30,7 +30,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_atlantis_allowed_repo_names"></a> [atlantis\_allowed\_repo\_names](#input\_atlantis\_allowed\_repo\_names) | List of names of repositories which belong to the owner specified in `github_owner` | `list(string)` | n/a | yes |
 | <a name="input_create_github_repository_webhook"></a> [create\_github\_repository\_webhook](#input\_create\_github\_repository\_webhook) | Whether to create Github repository webhook for Atlantis | `bool` | `true` | no |
-| <a name="input_github_base_url"></a> [github\_base_url](#input\_github\_base_url) | Github base URL to use when creating webhook (when using GitHub Enterprise) | `string` | `""` | no |
+| <a name="input_github_base_url"></a> [github\_base\_url](#input\_github\_base\_url) | Github base URL to use when creating webhook (when using GitHub Enterprise) | `string` | `null` | no |
 | <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Github owner to use when creating webhook | `string` | `""` | no |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token to use when creating webhook | `string` | `""` | no |
 | <a name="input_webhook_secret"></a> [webhook\_secret](#input\_webhook\_secret) | Webhook secret | `string` | `""` | no |

--- a/modules/github-repository-webhook/README.md
+++ b/modules/github-repository-webhook/README.md
@@ -30,6 +30,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_atlantis_allowed_repo_names"></a> [atlantis\_allowed\_repo\_names](#input\_atlantis\_allowed\_repo\_names) | List of names of repositories which belong to the owner specified in `github_owner` | `list(string)` | n/a | yes |
 | <a name="input_create_github_repository_webhook"></a> [create\_github\_repository\_webhook](#input\_create\_github\_repository\_webhook) | Whether to create Github repository webhook for Atlantis | `bool` | `true` | no |
+| <a name="input_github_base_url"></a> [github\_base_url](#input\_github\_base_url) | Github base URL to use when creating webhook (when using GitHub Enterprise) | `string` | `""` | no |
 | <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Github owner to use when creating webhook | `string` | `""` | no |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token to use when creating webhook | `string` | `""` | no |
 | <a name="input_webhook_secret"></a> [webhook\_secret](#input\_webhook\_secret) | Webhook secret | `string` | `""` | no |

--- a/modules/github-repository-webhook/main.tf
+++ b/modules/github-repository-webhook/main.tf
@@ -1,6 +1,7 @@
 provider "github" {
-  token = var.github_token
-  owner = var.github_owner
+  base_url = var.github_base_url
+  token    = var.github_token
+  owner    = var.github_owner
 }
 
 resource "github_repository_webhook" "this" {

--- a/modules/github-repository-webhook/variables.tf
+++ b/modules/github-repository-webhook/variables.tf
@@ -7,7 +7,7 @@ variable "create_github_repository_webhook" {
 variable "github_base_url" {
   description = "Github base URL to use when creating webhook (when using GitHub Enterprise)"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "github_token" {

--- a/modules/github-repository-webhook/variables.tf
+++ b/modules/github-repository-webhook/variables.tf
@@ -4,6 +4,12 @@ variable "create_github_repository_webhook" {
   default     = true
 }
 
+variable "github_base_url" {
+  description = "Github base URL to use when creating webhook (when using GitHub Enterprise)"
+  type        = string
+  default     = ""
+}
+
 variable "github_token" {
   description = "Github token to use when creating webhook"
   type        = string


### PR DESCRIPTION
## Description

Add base URL for use with GitHub Enterprise.

## Motivation and Context

Currently, the only way to use the module with GItHub Enterprise is via injecting the provider configuration. However, in recent versions of Terraform, `terraform validate` will treat it as an error. Adding a variable solves this issue.

## Breaking Changes

No known.

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects