### PR TITLE
fix: Secrets in task definition should be as ARN 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ locals {
 
   # token
   secret_name_key        = local.has_secrets ? var.atlantis_gitlab_user_token != "" ? "ATLANTIS_GITLAB_TOKEN" : var.atlantis_github_user_token != "" ? "ATLANTIS_GH_TOKEN" : "ATLANTIS_BITBUCKET_TOKEN" : ""
-  secret_name_value_from = local.has_secrets ? var.atlantis_gitlab_user_token != "" ? data.aws_ssm_parameter.atlantis_github_user_token.arn : var.atlantis_github_user_token != "" ? aws_ssm_parameter.atlantis_github_user_token.arn : aws_ssm_parameter.atlantis_bitbucket_user_token.arn : ""
+  secret_name_value_from = local.has_secrets ? var.atlantis_gitlab_user_token != "" ? aws_ssm_parameter.atlantis_github_user_token[0].arn : var.atlantis_github_user_token != "" ? aws_ssm_parameter.atlantis_github_user_token[0].arn : aws_ssm_parameter.atlantis_bitbucket_user_token[0].arn : ""
 
   # webhook
   secret_webhook_key = local.has_secrets || var.atlantis_github_webhook_secret != "" ? var.atlantis_gitlab_user_token != "" ? "ATLANTIS_GITLAB_WEBHOOK_SECRET" : var.atlantis_github_user_token != "" || var.atlantis_github_webhook_secret != "" ? "ATLANTIS_GH_WEBHOOK_SECRET" : "ATLANTIS_BITBUCKET_WEBHOOK_SECRET" : ""
@@ -95,7 +95,7 @@ locals {
   container_definition_secrets_2 = local.secret_webhook_key != "" ? [
     {
       name      = local.secret_webhook_key
-      valueFrom = aws_ssm_parameter.webhook.arn
+      valueFrom = aws_ssm_parameter.webhook[0].arn
     },
   ] : []
 

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ locals {
 
   # token
   secret_name_key        = local.has_secrets ? var.atlantis_gitlab_user_token != "" ? "ATLANTIS_GITLAB_TOKEN" : var.atlantis_github_user_token != "" ? "ATLANTIS_GH_TOKEN" : "ATLANTIS_BITBUCKET_TOKEN" : ""
-  secret_name_value_from = local.has_secrets ? var.atlantis_gitlab_user_token != "" ? var.atlantis_gitlab_user_token_ssm_parameter_name : var.atlantis_github_user_token != "" ? var.atlantis_github_user_token_ssm_parameter_name : var.atlantis_bitbucket_user_token_ssm_parameter_name : ""
+  secret_name_value_from = local.has_secrets ? var.atlantis_gitlab_user_token != "" ? data.aws_ssm_parameter.atlantis_github_user_token.arn : var.atlantis_github_user_token != "" ? aws_ssm_parameter.atlantis_github_user_token.arn : aws_ssm_parameter.atlantis_bitbucket_user_token.arn : ""
 
   # webhook
   secret_webhook_key = local.has_secrets || var.atlantis_github_webhook_secret != "" ? var.atlantis_gitlab_user_token != "" ? "ATLANTIS_GITLAB_WEBHOOK_SECRET" : var.atlantis_github_user_token != "" || var.atlantis_github_webhook_secret != "" ? "ATLANTIS_GH_WEBHOOK_SECRET" : "ATLANTIS_BITBUCKET_WEBHOOK_SECRET" : ""
@@ -95,7 +95,7 @@ locals {
   container_definition_secrets_2 = local.secret_webhook_key != "" ? [
     {
       name      = local.secret_webhook_key
-      valueFrom = var.webhook_ssm_parameter_name
+      valueFrom = aws_ssm_parameter.webhook.arn
     },
   ] : []
 

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ locals {
 
   # token
   secret_name_key        = local.has_secrets ? var.atlantis_gitlab_user_token != "" ? "ATLANTIS_GITLAB_TOKEN" : var.atlantis_github_user_token != "" ? "ATLANTIS_GH_TOKEN" : "ATLANTIS_BITBUCKET_TOKEN" : ""
-  secret_name_value_from = local.has_secrets ? var.atlantis_gitlab_user_token != "" ? aws_ssm_parameter.atlantis_github_user_token[0].arn : var.atlantis_github_user_token != "" ? aws_ssm_parameter.atlantis_github_user_token[0].arn : aws_ssm_parameter.atlantis_bitbucket_user_token[0].arn : ""
+  secret_name_value_from = local.has_secrets ? var.atlantis_gitlab_user_token != "" ? aws_ssm_parameter.atlantis_gitlab_user_token[0].arn : var.atlantis_github_user_token != "" ? aws_ssm_parameter.atlantis_github_user_token[0].arn : aws_ssm_parameter.atlantis_bitbucket_user_token[0].arn : ""
 
   # webhook
   secret_webhook_key = local.has_secrets || var.atlantis_github_webhook_secret != "" ? var.atlantis_gitlab_user_token != "" ? "ATLANTIS_GITLAB_WEBHOOK_SECRET" : var.atlantis_github_user_token != "" || var.atlantis_github_webhook_secret != "" ? "ATLANTIS_GH_WEBHOOK_SECRET" : "ATLANTIS_BITBUCKET_WEBHOOK_SECRET" : ""


### PR DESCRIPTION
## Description
ECS `secrets` `valueFrom` should be as ARN

## Motivation and Context
[ContainerDefinition spec](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#ContainerDefinition-secrets)

current implementation puts into `valueFrom` string with SSM parameter path and ECS task cannot start

## Breaking Changes
No

## How Has This Been Tested?
It was tested with 

```
module "test" {
  source = "git::https://github.com/borissavelev/terraform-aws-atlantis.git?ref=SSM_fixes"

  atlantis_github_user       = var.github_user
  atlantis_github_user_token = var.github_token
}
```
