### PR TITLE
fix: Use random_password resource instead of random_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ allow_github_webhooks        = true
 | [aws_ssm_parameter.atlantis_github_user_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.atlantis_gitlab_user_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.webhook](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
-| [random_id.webhook](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [random_password.webhook](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [aws_ecs_task_definition.atlantis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_task_definition) | data source |
 | [aws_iam_policy_document.ecs_task_access_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ecs_task_access_secrets_with_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/main.tf
+++ b/main.tf
@@ -126,10 +126,11 @@ data "aws_route53_zone" "this" {
 ################################################################################
 # Secret for webhook
 ################################################################################
-resource "random_id" "webhook" {
+resource "random_password" "webhook" {
   count = var.atlantis_github_webhook_secret != "" ? 0 : 1
 
-  byte_length = "64"
+  special = true
+  length  = "64"
 }
 
 resource "aws_ssm_parameter" "webhook" {
@@ -137,7 +138,7 @@ resource "aws_ssm_parameter" "webhook" {
 
   name  = var.webhook_ssm_parameter_name
   type  = "SecureString"
-  value = coalesce(var.atlantis_github_webhook_secret, join("", random_id.webhook.*.hex))
+  value = coalesce(var.atlantis_github_webhook_secret, random_password.webhook[0].result)
 
   tags = local.tags
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,7 +16,7 @@ output "atlantis_allowed_repo_names" {
 
 output "webhook_secret" {
   description = "Webhook secret"
-  value       = try(random_id.webhook[0].hex, "")
+  value       = try(random_password.webhook[0].result, "")
   sensitive   = true
 }
 


### PR DESCRIPTION

## Description
- Use `random_password.result` instead of `random_id.hex` since this is a resource specifically intended for secrets

## Motivation and Context
Fixes #158

## Breaking Changes
None

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
