### PR TITLE
fix: EFS encryption by default and variable support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -428,6 +428,10 @@ resource "aws_route53_record" "atlantis" {
 resource "aws_efs_file_system" "this" {
   count = var.enable_ephemeral_storage ? 0 : 1
 
+  encrypted      = var.efs_encrption_enabled 
+  kms_key_id     = var.efs_kms_key_id
+  tags           = merge(var.efs_additional_tags, local.tags) 
+
   creation_token = var.name
 }
 

--- a/main.tf
+++ b/main.tf
@@ -424,15 +424,22 @@ resource "aws_route53_record" "atlantis" {
 ################################################################################
 # EFS
 ################################################################################
-
 resource "aws_efs_file_system" "this" {
   count = var.enable_ephemeral_storage ? 0 : 1
 
-  encrypted      = var.efs_encrption_enabled 
-  kms_key_id     = var.efs_kms_key_id
-  tags           = merge(var.efs_additional_tags, local.tags) 
+  encrypted                         = var.efs_encrption_enabled 
+  kms_key_id                        = var.efs_kms_key_id
 
-  creation_token = var.name
+  performance_mode                  = var.efs_performance_mode
+  lifecycle_policy                  = var.efs_lifecycle_policy 
+
+  throughput_mode                   = var.efs_throughput_mode
+  provisioned_throughput_in_mibps   = var.provisioned_throughput_in_mibps 
+
+  creation_token                    = var.name
+
+  tags                              = merge(var.efs_additional_tags, local.tags) 
+  
 }
 
 resource "aws_efs_mount_target" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -688,3 +688,46 @@ variable "ephemeral_storage_size" {
     error_message = "The minimum supported value is 21 GiB and the maximum supported value is 200 GiB."
   }
 }
+
+# EFS
+variable "efs_encryption_enabled" {
+  description  = "(Optional) If true, the disk will be encrypted for this Atlantis EFS storage. Default is true"
+  default      = true 
+  type         = bool
+}
+
+variable "efs_kms_key_id" {
+  description  = "(Optional) The ARN for the KMS encryption key you wish to use to encrypt this Atlantis EFS with. When specifying `efs_kms_key_id`, encrypted needs to be set to true."
+  default      = null 
+  type         = string 
+}
+
+variable "efs_lifecycle_policy" {
+  description  = "(Optional) A file system [lifecycle policy](https://docs.aws.amazon.com/efs/latest/ug/API_LifecyclePolicy.html) object."
+  default      = null
+  type         = map(any)
+}
+
+variable "efs_performance_mode" {
+  description  = "(Optional) The file system performance mode. Can be either `generalPurpose` or `maxIO` (Default: `generalPurpose`)."
+  default      = null 
+  type         = string 
+}
+
+variable "efs_additional_tags" {
+  description  = "(Optional) Additional tags you would like to add to the EFS for this Atlanis instance"
+  default      = {}
+  type         = map(any)
+}
+
+variable "efs_provisioned_throughput_in_mibps" {
+  description  = "(Optional) The throughput, measured in MiB/s, that you want to provision for the file system. Only applicable with throughput_mode set to provisioned."
+  type         = string 
+  default      = null
+}
+
+variable "efs_throughput_mode" {
+  description  = "(Optional) Throughput mode for the file system. Defaults to `bursting`. Valid values: `bursting`, `provisioned`. When using `provisioned`, also set `efs_provisioned_throughput_in_mibps`."
+  type         = string 
+  default      = null
+}


### PR DESCRIPTION
## Description
* Enabled encryption on EFS by default.  
* Added `kms_key_id` support if a user wants to optionally encrypt their atlantis EFS with their own CMK
* Added `efs_` variables to turn these features on and off as necessary by a user
* Added `efs_additional_tags` so a user can add additional EFS tags as necessary, otherwise we will use the standard `local.tags` for this EFS module
* Added support for other portions of the `aws_efs_file_system` resource here, and set the appropriate variables so a user and turn things on and off as they wish.  https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Not having EFS encrypted by default is a security risk and a violation in any mature organization.  Enabling this by default is best practice and will enable more and more users of this moudule to adopt EFS support for Atlantis
<!--- If it fixes an open issue, please link to the issue here. -->
This [pr](https://github.com/terraform-aws-modules/terraform-aws-atlantis/pull/257) has been open, but doenst added kms_key support.  This PR addressed #257 and then some

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
It should not break anything as the module stands today
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
I have not been able to test these changes since this PR has to come from my personal github account and I dont have access to an area to fully build out a new atlantis to test.  
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
