### PR TITLE
feat: Allow ACM certificate usage when using private hosted zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,8 @@ allow_github_webhooks        = true
 | [aws_iam_policy_document.ecs_tasks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
-| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [aws_route53_zone.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [aws_route53_zone.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 
 ## Inputs
 
@@ -376,9 +377,9 @@ allow_github_webhooks        = true
 | <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | A list of public subnets inside the VPC | `list(string)` | `[]` | no |
 | <a name="input_readonly_root_filesystem"></a> [readonly\_root\_filesystem](#input\_readonly\_root\_filesystem) | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value | `bool` | `false` | no |
 | <a name="input_repository_credentials"></a> [repository\_credentials](#input\_repository\_credentials) | Container repository credentials; required when using a private repo.  This map currently supports a single key; "credentialsParameter", which should be the ARN of a Secrets Manager's secret holding the credentials | `map(string)` | `null` | no |
-| <a name="input_route53_private_zone"></a> [route53\_private\_zone](#input\_route53\_private\_zone) | Enable to use a private Route53 zone | `bool` | `false` | no |
+| <a name="input_route53_private_zone_name"></a> [route53\_private\_zone\_name](#input\_route53\_private\_zone\_name) | Private Route53 zone name to create the main A-record, without trailing dot | `string` | `""` | no |
+| <a name="input_route53_public_zone_name"></a> [route53\_public\_zone\_name](#input\_route53\_public\_zone\_name) | Public Route53 zone name to create ACM certificate in and main A-record, without trailing dot | `string` | `""` | no |
 | <a name="input_route53_record_name"></a> [route53\_record\_name](#input\_route53\_record\_name) | Name of Route53 record to create ACM certificate in and main A-record. If null is specified, var.name is used instead. Provide empty string to point root domain name to ALB. | `string` | `null` | no |
-| <a name="input_route53_zone_name"></a> [route53\_zone\_name](#input\_route53\_zone\_name) | Route53 zone name to create ACM certificate in and main A-record, without trailing dot | `string` | `""` | no |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | List of one or more security groups to be added to the load balancer | `list(string)` | `[]` | no |
 | <a name="input_ssm_kms_key_arn"></a> [ssm\_kms\_key\_arn](#input\_ssm\_kms\_key\_arn) | ARN of KMS key to use for encryption and decryption of SSM Parameters. Required only if your key uses a custom KMS key and not the default key | `string` | `""` | no |
 | <a name="input_start_timeout"></a> [start\_timeout](#input\_start\_timeout) | Time duration (in seconds) to wait before giving up on resolving dependencies for a container | `number` | `30` | no |

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ module "atlantis" {
   public_subnets  = ["10.20.101.0/24", "10.20.102.0/24", "10.20.103.0/24"]
 
   # DNS (without trailing dot)
-  route53_zone_name = "example.com"
+  route53_public_zone_name = "example.com"
 
   # ACM (SSL certificate) - Specify ARN of an existing certificate or new one will be created and validated using Route53 DNS
   certificate_arn = "arn:aws:acm:eu-west-1:135367859851:certificate/70e008e1-c0e1-4c7e-9670-7bb5bd4f5a84"
@@ -210,7 +210,7 @@ allow_github_webhooks        = true
 
 ## Notes
 
-1. AWS Route53 zone is not created by this module, so zone specified as a value in `route53_zone_name` should be created before using this module. Check documentation for [aws_route53_zone](https://www.terraform.io/docs/providers/aws/r/route53_zone.html).
+1. AWS Route53 zone is not created by this module, so zones specified as a value in `route53_public_zone_name` or `route53_private_zone_name` should be created before using this module. Check documentation for [aws_route53_zone](https://www.terraform.io/docs/providers/aws/r/route53_zone.html).
 1. Currently this module configures Atlantis in a way that it can not be used to work with GitHub and Gitlab simultaneously (can't make list of ECS secrets conditionally).
 1. For Bitbucket Cloud webhook configuration follow instructions in [the official Atlantis documentation](https://www.runatlantis.io/docs/configuring-webhooks.html#bitbucket-cloud-bitbucket-org-webhook).
 
@@ -287,7 +287,7 @@ allow_github_webhooks        = true
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_acm_certificate_domain_name"></a> [acm\_certificate\_domain\_name](#input\_acm\_certificate\_domain\_name) | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance. Specify if it is different from value in `route53_zone_name` | `string` | `""` | no |
+| <a name="input_acm_certificate_domain_name"></a> [acm\_certificate\_domain\_name](#input\_acm\_certificate\_domain\_name) | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance. Specify if it is different from value in `route53_public_zone_name` | `string` | `""` | no |
 | <a name="input_alb_authenticate_cognito"></a> [alb\_authenticate\_cognito](#input\_alb\_authenticate\_cognito) | Map of AWS Cognito authentication parameters to protect ALB (eg, using SAML). See https://www.terraform.io/docs/providers/aws/r/lb_listener.html#authenticate-cognito-action | `any` | `{}` | no |
 | <a name="input_alb_authenticate_oidc"></a> [alb\_authenticate\_oidc](#input\_alb\_authenticate\_oidc) | Map of Authenticate OIDC parameters to protect ALB (eg, using Auth0). See https://www.terraform.io/docs/providers/aws/r/lb_listener.html#authenticate-oidc-action | `any` | `{}` | no |
 | <a name="input_alb_drop_invalid_header_fields"></a> [alb\_drop\_invalid\_header\_fields](#input\_alb\_drop\_invalid\_header\_fields) | Indicates whether invalid header fields are dropped in application load balancers. Defaults to false. | `bool` | `null` | no |

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -65,7 +65,7 @@ module "atlantis" {
   }]
 
   # DNS
-  route53_zone_name = var.domain
+  route53_public_zone_name = var.domain
 
   # Trusted roles
   trusted_principals = ["ssm.amazonaws.com"]

--- a/terraform.tfvars.sample
+++ b/terraform.tfvars.sample
@@ -13,7 +13,7 @@ public_subnets = ["10.10.11.0/24", "10.10.12.0/24"]
 # public_subnet_ids = ["subnet-1211eef5", "subnet-163466ab"]
 
 # DNS
-route53_zone_name = "example.com"
+route53_public_zone_name = "example.com"
 
 # ACM (SSL certificate)
 # Specify ARN of an existing certificate or new one will be created and validated using Route53 DNS:

--- a/variables.tf
+++ b/variables.tf
@@ -206,7 +206,7 @@ variable "certificate_arn" {
 }
 
 variable "acm_certificate_domain_name" {
-  description = "Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance. Specify if it is different from value in `route53_zone_name`"
+  description = "Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance. Specify if it is different from value in `route53_public_zone_name`"
   type        = string
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -212,8 +212,14 @@ variable "acm_certificate_domain_name" {
 }
 
 # Route53
-variable "route53_zone_name" {
-  description = "Route53 zone name to create ACM certificate in and main A-record, without trailing dot"
+variable "route53_public_zone_name" {
+  description = "Public Route53 zone name to create ACM certificate in and main A-record, without trailing dot"
+  type        = string
+  default     = ""
+}
+
+variable "route53_private_zone_name" {
+  description = "Private Route53 zone name to create the main A-record, without trailing dot"
   type        = string
   default     = ""
 }
@@ -222,12 +228,6 @@ variable "route53_record_name" {
   description = "Name of Route53 record to create ACM certificate in and main A-record. If null is specified, var.name is used instead. Provide empty string to point root domain name to ALB."
   type        = string
   default     = null
-}
-
-variable "route53_private_zone" {
-  description = "Enable to use a private Route53 zone"
-  type        = bool
-  default     = false
 }
 
 variable "create_route53_record" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Allow ACM certificate usage when using private hosted zones

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes [#266](https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/266)

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
- Variables rename: `route53_zone_name` to `route53_public_zone_name`
- New variable: `route53_private_zone_name`
- Variable removal: `route53_private_zone`

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
