### PR TITLE
feat: Added support for GitHub app

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ allow_github_webhooks        = true
 | [aws_route53_record.atlantis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.atlantis_aaaa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_ssm_parameter.atlantis_bitbucket_user_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.atlantis_github_app_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.atlantis_github_user_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.atlantis_gitlab_user_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.webhook](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
@@ -313,6 +314,9 @@ allow_github_webhooks        = true
 | <a name="input_atlantis_bitbucket_user_token"></a> [atlantis\_bitbucket\_user\_token](#input\_atlantis\_bitbucket\_user\_token) | Bitbucket token of the user that is running the Atlantis command | `string` | `""` | no |
 | <a name="input_atlantis_bitbucket_user_token_ssm_parameter_name"></a> [atlantis\_bitbucket\_user\_token\_ssm\_parameter\_name](#input\_atlantis\_bitbucket\_user\_token\_ssm\_parameter\_name) | Name of SSM parameter to keep atlantis\_bitbucket\_user\_token | `string` | `"/atlantis/bitbucket/user/token"` | no |
 | <a name="input_atlantis_fqdn"></a> [atlantis\_fqdn](#input\_atlantis\_fqdn) | FQDN of Atlantis to use. Set this only to override Route53 and ALB's DNS name. | `string` | `null` | no |
+| <a name="input_atlantis_github_app_id"></a> [atlantis\_github\_app\_id](#input\_atlantis\_github\_app\_id) | GitHub App ID that is running the Atlantis command | `string` | `""` | no |
+| <a name="input_atlantis_github_app_key"></a> [atlantis\_github\_app\_key](#input\_atlantis\_github\_app\_key) | GitHub App private key that is running the Atlantis command | `string` | `""` | no |
+| <a name="input_atlantis_github_app_key_ssm_parameter_name"></a> [atlantis\_github\_app\_key\_ssm\_parameter\_name](#input\_atlantis\_github\_app\_key\_ssm\_parameter\_name) | Name of SSM parameter to keep atlantis\_github\_app\_key | `string` | `"/atlantis/github/app/key"` | no |
 | <a name="input_atlantis_github_user"></a> [atlantis\_github\_user](#input\_atlantis\_github\_user) | GitHub username that is running the Atlantis command | `string` | `""` | no |
 | <a name="input_atlantis_github_user_token"></a> [atlantis\_github\_user\_token](#input\_atlantis\_github\_user\_token) | GitHub token of the user that is running the Atlantis command | `string` | `""` | no |
 | <a name="input_atlantis_github_user_token_ssm_parameter_name"></a> [atlantis\_github\_user\_token\_ssm\_parameter\_name](#input\_atlantis\_github\_user\_token\_ssm\_parameter\_name) | Name of SSM parameter to keep atlantis\_github\_user\_token | `string` | `"/atlantis/github/user/token"` | no |
@@ -328,6 +332,7 @@ allow_github_webhooks        = true
 | <a name="input_atlantis_repo_allowlist"></a> [atlantis\_repo\_allowlist](#input\_atlantis\_repo\_allowlist) | List of allowed repositories Atlantis can be used with | `list(string)` | n/a | yes |
 | <a name="input_atlantis_security_group_tags"></a> [atlantis\_security\_group\_tags](#input\_atlantis\_security\_group\_tags) | Additional tags to put on the atlantis security group | `map(string)` | `{}` | no |
 | <a name="input_atlantis_version"></a> [atlantis\_version](#input\_atlantis\_version) | Verion of Atlantis to run. If not specified latest will be used | `string` | `"latest"` | no |
+| <a name="input_atlantis_write_git_creds"></a> [atlantis\_write\_git\_creds](#input\_atlantis\_write\_git\_creds) | Write out a .git-credentials file with the provider user and token to allow cloning private modules over HTTPS or SSH | `string` | `"true"` | no |
 | <a name="input_azs"></a> [azs](#input\_azs) | A list of availability zones in the region | `list(string)` | `[]` | no |
 | <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | ARN of certificate issued by AWS ACM. If empty, a new ACM certificate will be created and validated using Route53 DNS | `string` | `""` | no |
 | <a name="input_cidr"></a> [cidr](#input\_cidr) | The CIDR block for the VPC which will be created if `vpc_id` is not specified | `string` | `""` | no |

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -81,6 +81,7 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 | <a name="input_github_app_key"></a> [github\_app\_key](#input\_github\_app\_key) | The PEM encoded private key for the GitHub App | `string` | n/a | yes |
 | <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Github owner | `string` | n/a | yes |
 | <a name="input_github_repo_names"></a> [github\_repo\_names](#input\_github\_repo\_names) | List of Github repositories that should be monitored by Atlantis | `list(string)` | n/a | yes |
+| <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token | `string` | n/a | yes |
 | <a name="input_github_user"></a> [github\_user](#input\_github\_user) | Github user for Atlantis to utilize when performing Github activities | `string` | n/a | yes |
 | <a name="input_github_webhook_secret"></a> [github\_webhook\_secret](#input\_github\_webhook\_secret) | Webhook secret | `string` | n/a | yes |
 

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -1,10 +1,25 @@
-# Complete Atlantis example with GitHub Webhooks
+# Complete Atlantis example with GitHub App and Webhooks
 
 Configuration in this directory creates the necessary infrastructure and resources for running Atlantis on Fargate plus GitHub repository webhooks configured to Atlantis URL.
 
 An existing Route53 hosted zone and domain is required to deploy this example.
 
-GitHub's personal access token can be generated at https://github.com/settings/tokens
+The GitHub App can be generated using multiple methods:
+
+- You can follow Atlantis instructions depicted [here](https://www.runatlantis.io/docs/access-credentials.html#github-app). The Atlantis method mostly automates the GitHub App generation using [GitHub App Manifest](https://docs.github.com/en/developers/apps/building-github-apps/creating-a-github-app-from-a-manifest), but you need an exposed endpoint to complete the process.
+- The other method is to manually create the GitHub App as instructed [here](https://docs.github.com/en/developers/apps/building-github-apps/creating-a-github-app).
+
+Once you have your GitHub App registered you will be able to access/manage the required parameters:
+
+- `atlantis_github_app_id` to identify the GitHub app.
+- `atlantis_github_app_key` to interact with GitHub.
+- `atlantis_github_webhook_secret` to receive and validate incoming webhook invocations from GitHub.
+
+## GitHub Personal Access Token (PAT) is no longer recommended
+
+While still supported, the use of GitHub Personal Access Token (PAT) is no longer the recommended method in favor of GitHub App.
+
+[GitHub Apps](https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps) provide more control over repository access/permissions and does not require the use of bot accounts.
 
 ## Usage
 
@@ -62,10 +77,12 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 |------|-------------|------|---------|:--------:|
 | <a name="input_alb_ingress_cidr_blocks"></a> [alb\_ingress\_cidr\_blocks](#input\_alb\_ingress\_cidr\_blocks) | List of IPv4 CIDR ranges to use on all ingress rules of the ALB - use your personal IP in the form of `x.x.x.x/32` for restricted testing | `list(string)` | n/a | yes |
 | <a name="input_domain"></a> [domain](#input\_domain) | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance | `string` | n/a | yes |
+| <a name="input_github_app_id"></a> [github\_app\_id](#input\_github\_app\_id) | GitHub App ID that is running the Atlantis command | `string` | n/a | yes |
+| <a name="input_github_app_key"></a> [github\_app\_key](#input\_github\_app\_key) | The PEM encoded private key for the GitHub App | `string` | n/a | yes |
 | <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Github owner | `string` | n/a | yes |
 | <a name="input_github_repo_names"></a> [github\_repo\_names](#input\_github\_repo\_names) | List of Github repositories that should be monitored by Atlantis | `list(string)` | n/a | yes |
-| <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token | `string` | n/a | yes |
 | <a name="input_github_user"></a> [github\_user](#input\_github\_user) | Github user for Atlantis to utilize when performing Github activities | `string` | n/a | yes |
+| <a name="input_github_webhook_secret"></a> [github\_webhook\_secret](#input\_github\_webhook\_secret) | Webhook secret | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -23,7 +23,7 @@ While still supported, the use of GitHub Personal Access Token (PAT) is no longe
 
 ## Usage
 
-To run this code you need to copy `terraform.tfvars.sample` into `terraform.tfvars` and update the values locally or specify them using environment variables (`TF_VAR_github_token=xxx`, `TF_VAR_github_owner=xxx`, etc.). Once ready, execute:
+To run this code you need to copy `terraform.tfvars.sample` into `terraform.tfvars` and update the values locally or specify them using environment variables (`TF_VAR_github_app_id=xxx`, `TF_VAR_github_owner=xxx`, etc.). Once ready, execute:
 
 ```bash
 $ terraform init
@@ -60,7 +60,6 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 |------|--------|---------|
 | <a name="module_atlantis"></a> [atlantis](#module\_atlantis) | ../../ | n/a |
 | <a name="module_atlantis_access_log_bucket"></a> [atlantis\_access\_log\_bucket](#module\_atlantis\_access\_log\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
-| <a name="module_github_repository_webhook"></a> [github\_repository\_webhook](#module\_github\_repository\_webhook) | ../../modules/github-repository-webhook | n/a |
 
 ## Resources
 
@@ -81,7 +80,6 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 | <a name="input_github_app_key"></a> [github\_app\_key](#input\_github\_app\_key) | The PEM encoded private key for the GitHub App | `string` | n/a | yes |
 | <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Github owner | `string` | n/a | yes |
 | <a name="input_github_repo_names"></a> [github\_repo\_names](#input\_github\_repo\_names) | List of Github repositories that should be monitored by Atlantis | `list(string)` | n/a | yes |
-| <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token | `string` | n/a | yes |
 | <a name="input_github_user"></a> [github\_user](#input\_github\_user) | Github user for Atlantis to utilize when performing Github activities | `string` | n/a | yes |
 | <a name="input_github_webhook_secret"></a> [github\_webhook\_secret](#input\_github\_webhook\_secret) | Webhook secret | `string` | n/a | yes |
 
@@ -92,7 +90,5 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 | <a name="output_atlantis_repo_allowlist"></a> [atlantis\_repo\_allowlist](#output\_atlantis\_repo\_allowlist) | Git repositories where webhook should be created |
 | <a name="output_atlantis_url"></a> [atlantis\_url](#output\_atlantis\_url) | URL of Atlantis |
 | <a name="output_ecs_task_definition"></a> [ecs\_task\_definition](#output\_ecs\_task\_definition) | Task definition for ECS service (used for external triggers) |
-| <a name="output_github_webhook_secret"></a> [github\_webhook\_secret](#output\_github\_webhook\_secret) | Github webhook secret |
-| <a name="output_github_webhook_urls"></a> [github\_webhook\_urls](#output\_github\_webhook\_urls) | Github webhook URL |
 | <a name="output_task_role_arn"></a> [task\_role\_arn](#output\_task\_role\_arn) | The Atlantis ECS task role arn |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -6,7 +6,7 @@ An existing Route53 hosted zone and domain is required to deploy this example.
 
 ## Usage
 
-To run this code you need to copy `terraform.tfvars.sample` into `terraform.tfvars` and update the values locally or specify them using environment variables (`TF_VAR_github_app_id=xxx`, `TF_VAR_github_owner=xxx`, etc.). Ensure that bootstrap_GitHub_app is `true`.  Once ready, execute:
+To run this code you need to copy `terraform.tfvars.sample` into `terraform.tfvars` and update the values locally or specify them using environment variables (`TF_VAR_github_app_id=xxx`, `TF_VAR_github_owner=xxx`, etc.). Ensure that `bootstrap_github_app` is `true`.  Once ready, execute:
 
 ```bash
 $ terraform init

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -82,10 +82,24 @@ module "atlantis" {
   permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/cloud/developer-boundary-policy"
   path                 = "/delegatedadmin/developer/"
 
-  # Atlantis
-  atlantis_github_user       = var.github_user
-  atlantis_github_user_token = var.github_token
-  atlantis_repo_allowlist    = [for repo in var.github_repo_names : "github.com/${var.github_owner}/${repo}"]
+  # Atlantis w/ GitHub user
+
+  atlantis_github_user    = var.github_user
+  atlantis_repo_allowlist = [for repo in var.github_repo_names : "github.com/${var.github_owner}/${repo}"]
+
+  # Atlantis w/ GitHub app
+
+  ################################################################################
+  # Suggestion: instead of allocating the values of the atlantis_github_app_key
+  # and atlantis_github_webhook_secret in the tfvars file,it is suggested to
+  # upload the values in the AWS Parameter Store of the atlantis account and
+  # call the values via the data source function
+  # (e.g. data.aws_ssm_parameter.ghapp_key.value) for security reasons.
+  ################################################################################
+
+  atlantis_github_app_id         = var.github_app_id
+  atlantis_github_app_key        = var.github_app_key
+  atlantis_github_webhook_secret = var.github_webhook_secret # webhook secret associated to GitHub app
 
   # ALB access
   alb_ingress_cidr_blocks         = var.alb_ingress_cidr_blocks
@@ -133,7 +147,7 @@ module "github_repository_webhook" {
   source = "../../modules/github-repository-webhook"
 
   github_owner = var.github_owner
-  github_token = var.github_token
+
 
   atlantis_repo_allowlist = var.github_repo_names
 

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -147,6 +147,7 @@ module "github_repository_webhook" {
   source = "../../modules/github-repository-webhook"
 
   github_owner = var.github_owner
+  github_token = var.github_token
 
 
   atlantis_repo_allowlist = var.github_repo_names

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -140,23 +140,6 @@ module "atlantis" {
 }
 
 ################################################################################
-# GitHub Webhooks
-################################################################################
-
-module "github_repository_webhook" {
-  source = "../../modules/github-repository-webhook"
-
-  github_owner = var.github_owner
-  github_token = var.github_token
-
-
-  atlantis_repo_allowlist = var.github_repo_names
-
-  webhook_url    = module.atlantis.atlantis_url_events
-  webhook_secret = module.atlantis.webhook_secret
-}
-
-################################################################################
 # ALB Access Log Bucket + Policy
 ################################################################################
 module "atlantis_access_log_bucket" {

--- a/examples/github-complete/outputs.tf
+++ b/examples/github-complete/outputs.tf
@@ -18,15 +18,3 @@ output "ecs_task_definition" {
   description = "Task definition for ECS service (used for external triggers)"
   value       = module.atlantis.ecs_task_definition
 }
-
-# Webhooks
-output "github_webhook_urls" {
-  description = "Github webhook URL"
-  value       = module.github_repository_webhook.repository_webhook_urls
-}
-
-output "github_webhook_secret" {
-  description = "Github webhook secret"
-  value       = module.github_repository_webhook.repository_webhook_secret
-  sensitive   = true
-}

--- a/examples/github-complete/terraform.tfvars.sample
+++ b/examples/github-complete/terraform.tfvars.sample
@@ -4,3 +4,6 @@ github_owner = "myorg"
 github_user = "atlantis"
 github_token = "mygithubpersonalaccesstokenforatlantis"
 github_repo_names = ["mycoolrepo1", "mycoolrepo2"]
+github_app_id = "mygithubappid"
+github_app_key = "-----BEGIN RSA PRIVATE KEY-----(...)"
+webhook_secret = "mywebhooksecretforatlantis"

--- a/examples/github-complete/terraform.tfvars.sample
+++ b/examples/github-complete/terraform.tfvars.sample
@@ -2,7 +2,6 @@ domain = "mydomain.com"
 alb_ingress_cidr_blocks = ["x.x.x.x/32"]
 github_owner = "myorg"
 github_user = "atlantis"
-github_token = "mygithubpersonalaccesstokenforatlantis"
 github_repo_names = ["mycoolrepo1", "mycoolrepo2"]
 github_app_id = "mygithubappid"
 github_app_key = "-----BEGIN RSA PRIVATE KEY-----(...)"

--- a/examples/github-complete/variables.tf
+++ b/examples/github-complete/variables.tf
@@ -8,11 +8,6 @@ variable "alb_ingress_cidr_blocks" {
   type        = list(string)
 }
 
-variable "github_token" {
-  description = "Github token"
-  type        = string
-}
-
 variable "github_owner" {
   description = "Github owner"
   type        = string

--- a/examples/github-complete/variables.tf
+++ b/examples/github-complete/variables.tf
@@ -8,6 +8,11 @@ variable "alb_ingress_cidr_blocks" {
   type        = list(string)
 }
 
+variable "github_token" {
+  description = "Github token"
+  type        = string
+}
+
 variable "github_owner" {
   description = "Github owner"
   type        = string

--- a/examples/github-complete/variables.tf
+++ b/examples/github-complete/variables.tf
@@ -8,11 +8,6 @@ variable "alb_ingress_cidr_blocks" {
   type        = list(string)
 }
 
-variable "github_token" {
-  description = "Github token"
-  type        = string
-}
-
 variable "github_owner" {
   description = "Github owner"
   type        = string
@@ -28,3 +23,17 @@ variable "github_repo_names" {
   type        = list(string)
 }
 
+variable "github_app_id" {
+  type        = string
+  description = "GitHub App ID that is running the Atlantis command"
+}
+
+variable "github_app_key" {
+  description = "The PEM encoded private key for the GitHub App"
+  type        = string
+}
+
+variable "github_webhook_secret" {
+  description = "Webhook secret"
+  type        = string
+}

--- a/examples/github-repository-webhook/README.md
+++ b/examples/github-repository-webhook/README.md
@@ -48,7 +48,6 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Github owner | `string` | n/a | yes |
-| <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/github-repository-webhook/README.md
+++ b/examples/github-repository-webhook/README.md
@@ -48,6 +48,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Github owner | `string` | n/a | yes |
+| <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/github-repository-webhook/main.tf
+++ b/examples/github-repository-webhook/main.tf
@@ -11,7 +11,7 @@ module "github_repository_webhook" {
 
   create_github_repository_webhook = true
 
-  github_token = var.github_token
+
   github_owner = var.github_owner
 
   # Fetching these attributes from created already Atlantis Terraform state file

--- a/examples/github-repository-webhook/main.tf
+++ b/examples/github-repository-webhook/main.tf
@@ -11,7 +11,7 @@ module "github_repository_webhook" {
 
   create_github_repository_webhook = true
 
-
+  github_token = var.github_token
   github_owner = var.github_owner
 
   # Fetching these attributes from created already Atlantis Terraform state file

--- a/examples/github-repository-webhook/variables.tf
+++ b/examples/github-repository-webhook/variables.tf
@@ -1,8 +1,3 @@
-variable "github_token" {
-  description = "Github token"
-  type        = string
-}
-
 variable "github_owner" {
   description = "Github owner"
   type        = string

--- a/examples/github-repository-webhook/variables.tf
+++ b/examples/github-repository-webhook/variables.tf
@@ -1,3 +1,8 @@
+variable "github_token" {
+  description = "Github token"
+  type        = string
+}
+
 variable "github_owner" {
   description = "Github owner"
   type        = string

--- a/main.tf
+++ b/main.tf
@@ -14,15 +14,15 @@ locals {
   )}"
   atlantis_url_events = "${local.atlantis_url}/events"
 
-  # Include only one group of secrets - for github, gitlab or bitbucket
-  has_secrets = var.atlantis_gitlab_user_token != "" || var.atlantis_github_user_token != "" || var.atlantis_bitbucket_user_token != ""
+  # Include only one group of secrets - for github, github app,  gitlab or bitbucket
+  has_secrets = try(coalesce(var.atlantis_gitlab_user_token, var.atlantis_github_user_token, var.atlantis_github_app_key, var.atlantis_bitbucket_user_token) != "", false)
 
-  # token
-  secret_name_key        = local.has_secrets ? var.atlantis_gitlab_user_token != "" ? "ATLANTIS_GITLAB_TOKEN" : var.atlantis_github_user_token != "" ? "ATLANTIS_GH_TOKEN" : "ATLANTIS_BITBUCKET_TOKEN" : ""
-  secret_name_value_from = local.has_secrets ? var.atlantis_gitlab_user_token != "" ? var.atlantis_gitlab_user_token_ssm_parameter_name : var.atlantis_github_user_token != "" ? var.atlantis_github_user_token_ssm_parameter_name : var.atlantis_bitbucket_user_token_ssm_parameter_name : ""
+  # token/key
+  secret_name_key        = local.has_secrets ? var.atlantis_gitlab_user_token != "" ? "ATLANTIS_GITLAB_TOKEN" : var.atlantis_github_user_token != "" ? "ATLANTIS_GH_TOKEN" : var.atlantis_github_app_key != "" ? "ATLANTIS_GH_APP_KEY" : "ATLANTIS_BITBUCKET_TOKEN" : ""
+  secret_name_value_from = local.has_secrets ? var.atlantis_gitlab_user_token != "" ? var.atlantis_gitlab_user_token_ssm_parameter_name : var.atlantis_github_user_token != "" ? var.atlantis_github_user_token_ssm_parameter_name : var.atlantis_github_app_key != "" ? var.atlantis_github_app_key_ssm_parameter_name : var.atlantis_bitbucket_user_token_ssm_parameter_name : ""
 
   # webhook
-  secret_webhook_key = local.has_secrets || var.atlantis_github_webhook_secret != "" ? var.atlantis_gitlab_user_token != "" ? "ATLANTIS_GITLAB_WEBHOOK_SECRET" : var.atlantis_github_user_token != "" || var.atlantis_github_webhook_secret != "" ? "ATLANTIS_GH_WEBHOOK_SECRET" : "ATLANTIS_BITBUCKET_WEBHOOK_SECRET" : ""
+  secret_webhook_key = local.has_secrets || var.atlantis_github_webhook_secret != "" ? var.atlantis_gitlab_user_token != "" ? "ATLANTIS_GITLAB_WEBHOOK_SECRET" : var.atlantis_github_user_token != "" || var.atlantis_github_webhook_secret != "" ? "ATLANTIS_GH_WEBHOOK_SECRET" : var.atlantis_github_app_key != "" || var.atlantis_github_webhook_secret != "" ? "ATLANTIS_GH_WEBHOOK_SECRET" : "ATLANTIS_BITBUCKET_WEBHOOK_SECRET" : ""
 
   # determine if the alb has authentication enabled, otherwise forward the traffic unauthenticated
   alb_authentication_method = length(keys(var.alb_authenticate_oidc)) > 0 ? "authenticate-oidc" : length(keys(var.alb_authenticate_cognito)) > 0 ? "authenticate-cognito" : "forward"
@@ -78,6 +78,14 @@ locals {
       name  = "ATLANTIS_HIDE_PREV_PLAN_COMMENTS"
       value = var.atlantis_hide_prev_plan_comments
     },
+    {
+      name  = "ATLANTIS_GH_APP_ID"
+      value = var.atlantis_github_app_id
+    },
+    {
+      name  = "ATLANTIS_WRITE_GIT_CREDS"
+      value = var.atlantis_write_git_creds
+    }
   ]
 
   # ECS task definition
@@ -182,6 +190,16 @@ resource "aws_ssm_parameter" "atlantis_bitbucket_user_token" {
   name  = var.atlantis_bitbucket_user_token_ssm_parameter_name
   type  = "SecureString"
   value = var.atlantis_bitbucket_user_token
+
+  tags = local.tags
+}
+
+resource "aws_ssm_parameter" "atlantis_github_app_key" {
+  count = var.atlantis_github_app_key != "" ? 1 : 0
+
+  name  = var.atlantis_github_app_key_ssm_parameter_name
+  type  = "SecureString"
+  value = var.atlantis_github_app_key
 
   tags = local.tags
 }
@@ -347,8 +365,7 @@ module "alb_http_sg" {
 
   ingress_cidr_blocks      = sort(compact(concat(var.allow_github_webhooks ? var.github_webhooks_cidr_blocks : [], var.alb_ingress_cidr_blocks)))
   ingress_ipv6_cidr_blocks = sort(compact(concat(var.allow_github_webhooks ? var.github_webhooks_ipv6_cidr_blocks : [], var.alb_ingress_ipv6_cidr_blocks)))
-
-  tags = merge(local.tags, var.alb_http_security_group_tags)
+  tags                     = merge(local.tags, var.alb_http_security_group_tags)
 }
 
 module "atlantis_sg" {
@@ -555,7 +572,8 @@ data "aws_iam_policy_document" "ecs_task_access_secrets" {
       aws_ssm_parameter.webhook.*.arn,
       aws_ssm_parameter.atlantis_github_user_token.*.arn,
       aws_ssm_parameter.atlantis_gitlab_user_token.*.arn,
-      aws_ssm_parameter.atlantis_bitbucket_user_token.*.arn
+      aws_ssm_parameter.atlantis_bitbucket_user_token.*.arn,
+      aws_ssm_parameter.atlantis_github_app_key.*.arn
     ])
 
     actions = [
@@ -579,7 +597,7 @@ data "aws_iam_policy_document" "ecs_task_access_secrets_with_kms" {
 }
 
 resource "aws_iam_role_policy" "ecs_task_access_secrets" {
-  count = var.atlantis_github_user_token != "" || var.atlantis_gitlab_user_token != "" || var.atlantis_bitbucket_user_token != "" ? 1 : 0
+  count = local.has_secrets ? 1 : 0
 
   name = "ECSTaskAccessSecretsPolicy"
 

--- a/variables.tf
+++ b/variables.tf
@@ -286,6 +286,12 @@ variable "atlantis_bitbucket_user_token_ssm_parameter_name" {
   default     = "/atlantis/bitbucket/user/token"
 }
 
+variable "atlantis_github_app_key_ssm_parameter_name" {
+  description = "Name of SSM parameter to keep atlantis_github_app_key"
+  type        = string
+  default     = "/atlantis/github/app/key"
+}
+
 variable "ssm_kms_key_arn" {
   description = "ARN of KMS key to use for encryption and decryption of SSM Parameters. Required only if your key uses a custom KMS key and not the default key"
   type        = string
@@ -575,9 +581,27 @@ variable "atlantis_hide_prev_plan_comments" {
   default     = "false"
 }
 
+variable "atlantis_write_git_creds" {
+  description = "Write out a .git-credentials file with the provider user and token to allow cloning private modules over HTTPS or SSH"
+  type        = string
+  default     = "true"
+}
+
 # Github
 variable "atlantis_github_user" {
   description = "GitHub username that is running the Atlantis command"
+  type        = string
+  default     = ""
+}
+
+variable "atlantis_github_app_id" {
+  description = "GitHub App ID that is running the Atlantis command"
+  type        = string
+  default     = ""
+}
+
+variable "atlantis_github_app_key" {
+  description = "GitHub App private key that is running the Atlantis command"
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Description
Allow users to utilize the GitHub App instead of a personal access token to execute Atlantis.

## Motivation and Context
Enable the use of a GitHub App with Atlantis. In this PR, four variables were added to the module and their dependencies: 
- `var.atlantis_github_app_key` 
- `var.atlantis_github_app_key_ssm_parameter_name`
- `var.atlantis_write_git_creds`
- `var.atlantis_github_app_id`

Note: It is not necessary to create a specific variable for the webhook secret in the GitHub App, the existing one can be used.

- fixes #271

ref:https://www.runatlantis.io/docs/access-credentials.html#generating-an-access-token (GitHub App section)


## Breaking Changes
None

## How Has This Been Tested?
- [x] I have executed `pre-commit run -a` on my pull request

Initially, a github app was created and consequently a private key and a secret webhook were associated with 
it. Posteriorly, a test repo was used with the inputs (atlantis_github_app_id, atlantis_github_app_key & atlantis_github_webhook_secret) from the github app to guarantee the communication between Atlantis and the GitHub app at the level of webhooks and comments and it was possible to guarantee this communication with success as well as the provisioning of resources.
