### PR TITLE
fix: Fix the GitHub Complete example

### DIFF
--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -65,6 +65,7 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 | <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Github owner | `string` | n/a | yes |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token | `string` | n/a | yes |
 | <a name="input_github_user"></a> [github\_user](#input\_github\_user) | Github user for Atlantis to utilize when performing Github activities | `string` | n/a | yes |
+| <a name="input_github_repo_names"></a> [github\_repo\_names](#input\_github\_repo\_names) | Github user for Atlantis to utilize when performing Github activities | `list(string)` | n/a | yes |
 
 ## Outputs
 

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -63,9 +63,9 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 | <a name="input_alb_ingress_cidr_blocks"></a> [alb\_ingress\_cidr\_blocks](#input\_alb\_ingress\_cidr\_blocks) | List of IPv4 CIDR ranges to use on all ingress rules of the ALB - use your personal IP in the form of `x.x.x.x/32` for restricted testing | `list(string)` | n/a | yes |
 | <a name="input_domain"></a> [domain](#input\_domain) | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance | `string` | n/a | yes |
 | <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Github owner | `string` | n/a | yes |
+| <a name="input_github_repo_names"></a> [github\_repo\_names](#input\_github\_repo\_names) | List of Github repositories that should be monitored by Atlantis | `list(string)` | n/a | yes |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token | `string` | n/a | yes |
 | <a name="input_github_user"></a> [github\_user](#input\_github\_user) | Github user for Atlantis to utilize when performing Github activities | `string` | n/a | yes |
-| <a name="input_github_repo_names"></a> [github\_repo\_names](#input\_github\_repo\_names) | Github user for Atlantis to utilize when performing Github activities | `list(string)` | n/a | yes |
 
 ## Outputs
 

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -76,7 +76,7 @@ module "atlantis" {
   # Atlantis
   atlantis_github_user       = var.github_user
   atlantis_github_user_token = var.github_token
-  atlantis_repo_allowlist    = ["github.com/${var.github_owner}/*"]
+  atlantis_repo_allowlist    = var.github_repo_names
 
   # ALB access
   alb_ingress_cidr_blocks         = var.alb_ingress_cidr_blocks

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -76,7 +76,7 @@ module "atlantis" {
   # Atlantis
   atlantis_github_user       = var.github_user
   atlantis_github_user_token = var.github_token
-  atlantis_repo_allowlist    = var.github_repo_names
+  atlantis_repo_allowlist    = [for repo in var.github_repo_names : "github.com/${repo}/*"]
 
   # ALB access
   alb_ingress_cidr_blocks         = var.alb_ingress_cidr_blocks
@@ -103,7 +103,7 @@ module "github_repository_webhook" {
   github_owner = var.github_owner
   github_token = var.github_token
 
-  atlantis_repo_allowlist = module.atlantis.atlantis_repo_allowlist
+  atlantis_repo_allowlist = var.github_repo_names
 
   webhook_url    = module.atlantis.atlantis_url_events
   webhook_secret = module.atlantis.webhook_secret

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -76,7 +76,7 @@ module "atlantis" {
   # Atlantis
   atlantis_github_user       = var.github_user
   atlantis_github_user_token = var.github_token
-  atlantis_repo_allowlist    = [for repo in var.github_repo_names : "github.com/${repo}/*"]
+  atlantis_repo_allowlist    = [for repo in var.github_repo_names : "github.com/${var.github_owner}/${repo}"]
 
   # ALB access
   alb_ingress_cidr_blocks         = var.alb_ingress_cidr_blocks

--- a/examples/github-complete/terraform.tfvars.sample
+++ b/examples/github-complete/terraform.tfvars.sample
@@ -3,3 +3,4 @@ alb_ingress_cidr_blocks = ["x.x.x.x/32"]
 github_owner = "myorg"
 github_user = "atlantis"
 github_token = "mygithubpersonalaccesstokenforatlantis"
+github_repo_names = ["mycoolrepo1", "mycoolrepo2"]

--- a/examples/github-complete/variables.tf
+++ b/examples/github-complete/variables.tf
@@ -22,3 +22,9 @@ variable "github_user" {
   description = "Github user for Atlantis to utilize when performing Github activities"
   type        = string
 }
+
+variable "github_repo_names" {
+  description = "List of Github repositories that should be monitored by Atlantis"
+  type        = list(string)
+}
+


### PR DESCRIPTION
## Description
The [GitHub Complete example](https://github.com/terraform-aws-modules/terraform-aws-atlantis/tree/master/examples/github-complete) is broken because of #253. This PR fixes it.

## Motivation and Context
I spend few hour trying to provision the Atlantis to Fargate with no luck. Then I found #253 and realised what was the issue. With these fixes everything executed without errors. 

## Breaking Changes
This PR touches only examples folder, so I don't think it will introduce any breaking change.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` project
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
