### PR TITLE
fix: EFS mount target for_each does not work if ephemeral storage is enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -451,10 +451,11 @@ resource "aws_efs_file_system" "this" {
 
 resource "aws_efs_mount_target" "this" {
   # we coalescelist in order to specify the resource keys when we create the subnets using the VPC or they're specified for us.  This works around the for_each value depends on attributes which can't be determined until apply error
-  for_each = {
-    for k, v in zipmap(coalescelist(var.private_subnets, var.private_subnet_ids), local.private_subnet_ids) : k => v
-    if var.enable_ephemeral_storage == false
-  }
+  for_each = (
+    var.enable_ephemeral_storage == false
+    ? { for k, v in zipmap(coalescelist(var.private_subnets, var.private_subnet_ids), local.private_subnet_ids) : k => v }
+    : {}
+  )
 
   file_system_id  = aws_efs_file_system.this[0].id
   subnet_id       = each.value


### PR DESCRIPTION
## Description
This PR reworks the `aws_efs_mount_target` `for_each` to handle enable ephemeral storage better. This is a reworking of https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/272.
<!--- Describe your changes in detail -->

## Motivation and Context

Versions:
* Terraform v1.1.9
* terragrunt version v0.37.1
* AWS provider 4.14.0

I was setting `enable_ephemeral_storage = true`, but despite that, I was getting this error:

```
│ Error: Invalid for_each argument
│
│   on .terraform/modules/atlantis.atlantis/main.tf line 454, in resource "aws_efs_mount_target" "this":
│  454:   for_each = {
│  455:     for k, v in zipmap(coalescelist(var.private_subnets, var.private_subnet_ids), local.private_subnet_ids) : k => v
│  456:     if var.enable_ephemeral_storage == false
│  457:   }
│     ├────────────────
│     │ local.private_subnet_ids is list of string with 2 elements
│     │ var.enable_ephemeral_storage is true
│     │ var.private_subnet_ids is list of string with 2 elements
│     │ var.private_subnets is empty list of string
│
│ The "for_each" value depends on resource attributes that cannot be
│ determined until apply, so Terraform cannot predict how many instances will
│ be created. To work around this, use the -target argument to first apply
│ only the resources that the for_each depends on.
```

## Breaking Changes
This only breaks the latest version if you're enabling ephemeral storage.

## How Has This Been Tested?

I made the change locally and was able to `terraform plan` correctly.

- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
