### PR TITLE
feat: Ensure EFS is owned by the posix_user to avoid permission issues

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -469,6 +469,15 @@ resource "aws_efs_access_point" "this" {
     gid = local.gid
     uid = local.uid
   }
+
+  root_directory {
+    path = "/"
+    creation_info {
+      owner_gid   = local.gid
+      owner_uid   = local.uid
+      permissions = 0750
+    }
+  }
 }
 
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -471,7 +471,7 @@ resource "aws_efs_access_point" "this" {
   }
 
   root_directory {
-    path = "/"
+    path = "/home/atlantis"
     creation_info {
       owner_gid   = local.gid
       owner_uid   = local.uid


### PR DESCRIPTION
## Description
When specifying a user for running the container, e.g. using the `100:1000` Atlantis user on the default image, the `aws_efs_access_point` is correctly configured with said `posix_user`, but the ownership of the root directory is left as the default `root:root`. This can result in different permission issues, one of which is described in https://github.com/runatlantis/atlantis/issues/2221. By specifying the `creation_info`, we ensure that the user provided as the executing posix user also owns the directory. If desired, this change can be put behind a feature variable.

## Motivation and Context
The issue described in https://github.com/runatlantis/atlantis/issues/2221 is the primary motivation for this change.

## Breaking Changes
No breaking changes as such, but this will force recreation of an existing aws_efs_access_point and thus the aws_ecs_task_definition.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
