### PR TITLE
feat: Add arguments in EFS file system

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ allow_github_webhooks        = true
 | <a name="input_ecs_service_platform_version"></a> [ecs\_service\_platform\_version](#input\_ecs\_service\_platform\_version) | The platform version on which to run your service | `string` | `"LATEST"` | no |
 | <a name="input_ecs_task_cpu"></a> [ecs\_task\_cpu](#input\_ecs\_task\_cpu) | The number of cpu units used by the task | `number` | `256` | no |
 | <a name="input_ecs_task_memory"></a> [ecs\_task\_memory](#input\_ecs\_task\_memory) | The amount (in MiB) of memory used by the task | `number` | `512` | no |
+| <a name="input_efs_file_system_token"></a> [efs\_file\_system\_token](#input\_efs\_file\_system\_token) | Be able to import other EFS instance created by the other module | `string` | `""` | no |
 | <a name="input_enable_ecs_managed_tags"></a> [enable\_ecs\_managed\_tags](#input\_enable\_ecs\_managed\_tags) | Specifies whether to enable Amazon ECS managed tags for the tasks within the service | `bool` | `false` | no |
 | <a name="input_enable_ephemeral_storage"></a> [enable\_ephemeral\_storage](#input\_enable\_ephemeral\_storage) | Enable to use Fargate Ephemeral Storage | `bool` | `false` | no |
 | <a name="input_entrypoint"></a> [entrypoint](#input\_entrypoint) | The entry point that is passed to the container | `list(string)` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -446,7 +446,7 @@ resource "aws_route53_record" "atlantis_aaaa" {
 resource "aws_efs_file_system" "this" {
   count = var.enable_ephemeral_storage ? 0 : 1
 
-  creation_token = var.efs_file_system_token != "" ? var.efs_file_system_token : var.name
+  creation_token = coalesce(var.efs_file_system_token, var.name)
 }
 
 resource "aws_efs_mount_target" "this" {

--- a/main.tf
+++ b/main.tf
@@ -446,7 +446,7 @@ resource "aws_route53_record" "atlantis_aaaa" {
 resource "aws_efs_file_system" "this" {
   count = var.enable_ephemeral_storage ? 0 : 1
 
-  creation_token = var.name
+  creation_token = var.efs_file_system_token != "" ? var.efs_file_system_token : var.name
 }
 
 resource "aws_efs_mount_target" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -701,6 +701,12 @@ variable "ephemeral_storage_size" {
   }
 }
 
+variable "efs_file_system_token" {
+  description = "Be able to import other EFS instance created by the other module"
+  type        = string
+  default     = ""
+}
+
 variable "alb_ip_address_type" {
   description = "The type of IP addresses used by the subnets for your load balancer. The possible values are ipv4 and dualstack"
   type        = string


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
1. Be able to import EFS file system created by the other terraform module

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
