### PR TITLE
fix: Unintentionally exposed endpoints when enabling github webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,6 @@ alb_authenticate_cognito = {
 If you are using one of the authentication methods above along with managed GitHub (not self-hosted enterprise version), you'll need to allow unauthenticated access to GitHub's Webhook static IPs:
 
 ```hcl
-allow_unauthenticated_access = true
 allow_github_webhooks        = true
 ```
 

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -91,9 +91,8 @@ module "atlantis" {
   alb_listener_ssl_policy_default = "ELBSecurityPolicy-TLS-1-2-2017-01"
   alb_drop_invalid_header_fields  = true
 
-  allow_unauthenticated_access = true
-  allow_github_webhooks        = true
-  allow_repo_config            = true
+  allow_github_webhooks = true
+  allow_repo_config     = true
 
   tags = local.tags
 }


### PR DESCRIPTION
## Description
When following the guide to allow access for github webhooks, then you're actually incorrectly exposing endpoints in the following ways:
1) All endpoints is allowed from github IPs
2) `/events` endpoint is allowed from the entire world

## Motivation and Context
Limiting exposed endpoints is a good security practice.

## Breaking Changes
It shouldn't except:
1) abusing the rules to have github webhooks hit other endpoints than `/events`
2) abusing the `allow_github_webhooks` option to allow webhooks from other systems than github

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
