### PR TITLE
feat: Add `task_execution_session_duration` for task execution role

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ allow_github_webhooks        = true
 | <a name="input_github_webhooks_ipv6_cidr_blocks"></a> [github\_webhooks\_ipv6\_cidr\_blocks](#input\_github\_webhooks\_ipv6\_cidr\_blocks) | List of IPv6 CIDR blocks used by GitHub webhooks | `list(string)` | <pre>[<br>  "2a0a:a440::/29",<br>  "2606:50c0::/32"<br>]</pre> | no |
 | <a name="input_internal"></a> [internal](#input\_internal) | Whether the load balancer is internal or external | `bool` | `false` | no |
 | <a name="input_manage_default_security_group"></a> [manage\_default\_security\_group](#input\_manage\_default\_security\_group) | Should be true to adopt and manage default security group | `bool` | `false` | no |
+| <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum session duration (in seconds) for ecs task execution role. Default is 3600. | `number` | `null` | no |
 | <a name="input_mount_points"></a> [mount\_points](#input\_mount\_points) | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume`. The `readOnly` key is optional. | `list(any)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to use on all resources created (VPC, ALB, etc) | `string` | `"atlantis"` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | If provided, all IAM roles will be created with this permissions boundary attached. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -530,6 +530,7 @@ data "aws_iam_policy_document" "ecs_tasks" {
 resource "aws_iam_role" "ecs_task_execution" {
   name                 = "${var.name}-ecs_task_execution"
   assume_role_policy   = data.aws_iam_policy_document.ecs_tasks.json
+  max_session_duration = var.max_session_duration
   permissions_boundary = var.permissions_boundary
 
   tags = local.tags

--- a/variables.tf
+++ b/variables.tf
@@ -718,3 +718,9 @@ variable "runtime_platform" {
   type        = any
   default     = null
 }
+
+variable "max_session_duration" {
+  description = "Maximum session duration (in seconds) for ecs task execution role. Default is 3600."
+  type        = number
+  default     = null
+}


### PR DESCRIPTION
## Description
Add `var.task_execution_session_duration` for task execution role.

![image](https://user-images.githubusercontent.com/382062/152218941-c0166b6a-872e-4a98-ae7f-9f2dfce2f455.png)
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role

## Motivation and Context
The default max_session_duration for iam roles of 1 hour is insufficient for long-running terraform applies. This leads to runs breaking and failing to persist their state in s3, and often requires painful manual cleanup.

## Breaking Changes
None

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
