### PR TITLE
add repository credentials to ecs_task_access_secrets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -552,7 +552,8 @@ data "aws_iam_policy_document" "ecs_task_access_secrets" {
       aws_ssm_parameter.webhook.*.arn,
       aws_ssm_parameter.atlantis_github_user_token.*.arn,
       aws_ssm_parameter.atlantis_gitlab_user_token.*.arn,
-      aws_ssm_parameter.atlantis_bitbucket_user_token.*.arn
+      aws_ssm_parameter.atlantis_bitbucket_user_token.*.arn,
+      var.repository_credentials != null && can(var.repository_credentials["credentialsParameter"]) ? [var.repository_credentials["credentialsParameter"]] : []
     ])
 
     actions = [


### PR DESCRIPTION
## Description
Add the `credentialsParameter` arn to the `ecs_task_access_secrets` policy if `var.repository_credentials` is not null and the `credentialsParameter` key exists in `var.repository_credentials`. 

## Motivation and Context
Without this change the access to this secret must be created outside the module and the policy must be passed in via `policies_arn`. Other parameters are currently granted access but `credentialsParameter` is an outlier.

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request

This change was tested internally with `credentialsParemeter` configured and without.
