### PR TITLE
Role policy allowing ecs task role to assume another role

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ allow_github_webhooks        = true
 | [aws_efs_file_system.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system) | resource |
 | [aws_efs_mount_target.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_mount_target) | resource |
 | [aws_iam_role.ecs_task_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.ecs_task_access_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.ecs_task_access_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.ecs_task_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lb_listener_rule.unauthenticated_access_for_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
@@ -372,6 +373,7 @@ allow_github_webhooks        = true
 | <a name="input_firelens_configuration"></a> [firelens\_configuration](#input\_firelens\_configuration) | The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html | <pre>object({<br>    type    = string<br>    options = map(string)<br>  })</pre> | `null` | no |
 | <a name="input_github_webhooks_cidr_blocks"></a> [github\_webhooks\_cidr\_blocks](#input\_github\_webhooks\_cidr\_blocks) | List of IPv4 CIDR blocks used by GitHub webhooks | `list(string)` | <pre>[<br>  "140.82.112.0/20",<br>  "185.199.108.0/22",<br>  "192.30.252.0/22",<br>  "143.55.64.0/20"<br>]</pre> | no |
 | <a name="input_github_webhooks_ipv6_cidr_blocks"></a> [github\_webhooks\_ipv6\_cidr\_blocks](#input\_github\_webhooks\_ipv6\_cidr\_blocks) | List of IPv6 CIDR blocks used by GitHub webhooks | `list(string)` | <pre>[<br>  "2a0a:a440::/29",<br>  "2606:50c0::/32"<br>]</pre> | no |
+| <a name="input_iam_assume_role_arn"></a> [iam\_assume\_role\_arn](#input\_iam\_assume\_role\_arn) | Role the ecs task role can assume | `string` | `""` | no |
 | <a name="input_internal"></a> [internal](#input\_internal) | Whether the load balancer is internal or external | `bool` | `false` | no |
 | <a name="input_manage_default_security_group"></a> [manage\_default\_security\_group](#input\_manage\_default\_security\_group) | Should be true to adopt and manage default security group | `bool` | `false` | no |
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum session duration (in seconds) for ecs task execution role. Default is 3600. | `number` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -595,6 +595,27 @@ resource "aws_iam_role_policy" "ecs_task_access_secrets" {
   )
 }
 
+resource "aws_iam_role_policy" "ecs_task_access_assume" {
+  count = var.iam_assume_role_arn == "" ? 0 : 1
+
+  name = "iam_assumre_role_policy"
+
+  role = aws_iam_role.ecs_task_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "sts:AssumeRole",
+        ]
+        Effect   = "Allow"
+        Resource = var.iam_assume_role_arn
+      },
+    ]
+  })
+}
+
 module "container_definition_github_gitlab" {
   source  = "cloudposse/ecs-container-definition/aws"
   version = "v0.58.1"

--- a/variables.tf
+++ b/variables.tf
@@ -736,3 +736,9 @@ variable "max_session_duration" {
   type        = number
   default     = null
 }
+
+variable "iam_assume_role_arn" {
+  description = "Role the ecs task role can assume"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR Gives a `aws_iam_role_policy` to the ecs_task role allowing it to assume the role passed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

- with out this if using the assume role approach to run atlantis there seems to be no other way to give the ecs_task role the permissions to assume the role.

<!--- If it fixes an open issue, please link to the issue here. -->
NA

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->

No, if variable not specified continues to work as is.

<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)

I've build an atlantis server based of the the [github-complete](https://github.com/terraform-aws-modules/terraform-aws-atlantis/tree/master/examples/github-complete) example, and ran this deployment off my fork. I didn't update the example here because the change is optional if not specified continues to work as before.

- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
no breaking changes with the change
<!--- Please describe how you tested your changes -->

I have build an atlantis fargate server module, i've used the the assume role functionality, By adding 

```tf
 module "atlantis" {
    source = "github.com/SamirMarin/terraform-aws-atlantis?ref=option-to-allow-assume-role-policy"

    iam_assume_role_arn = "arn:aws:iam::${local.account_id}:role/ci-runner"

  .....
  }


```
after this is applied it gives the ecs task role the permissions to assume ci-runner, I'm able to run atlantis plan assuming the the role specified in the `iam_assume_role_arn`

- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
