### PR TITLE
feat: Add path option to IAM roles created under this module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,6 @@
 repos:
-  - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.3
-    hooks:
-      - id: terraform_fmt
-      - id: terraform_validate
-      - id: terraform_docs
-        args:
-          - '--args=--lockfile=false'
-      - id: terraform_tflint
-        args:
-          - '--args=--only=terraform_deprecated_interpolation'
-          - '--args=--only=terraform_deprecated_index'
-          - '--args=--only=terraform_unused_declarations'
-          - '--args=--only=terraform_comment_syntax'
-          - '--args=--only=terraform_documented_outputs'
-          - '--args=--only=terraform_documented_variables'
-          - '--args=--only=terraform_typed_variables'
-          - '--args=--only=terraform_module_pinned_source'
-          - '--args=--only=terraform_naming_convention'
-          - '--args=--only=terraform_required_version'
-          - '--args=--only=terraform_required_providers'
-          - '--args=--only=terraform_standard_module_structure'
-          - '--args=--only=terraform_workspace_remote'
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
-    hooks:
-      - id: check-merge-conflict
+- repo: https://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.76.0 # Get the latest from: https://github.com/antonbabenko/pre-commit-terraform/releases
+  hooks:
+    - id: terraform_fmt
+    - id: terraform_docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,28 @@
 repos:
-- repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.76.0 # Get the latest from: https://github.com/antonbabenko/pre-commit-terraform/releases
-  hooks:
-    - id: terraform_fmt
-    - id: terraform_docs
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.76.0
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+      - id: terraform_docs
+        args:
+          - '--args=--lockfile=false'
+      - id: terraform_tflint
+        args:
+          - '--args=--only=terraform_deprecated_interpolation'
+          - '--args=--only=terraform_deprecated_index'
+          - '--args=--only=terraform_unused_declarations'
+          - '--args=--only=terraform_comment_syntax'
+          - '--args=--only=terraform_documented_outputs'
+          - '--args=--only=terraform_documented_variables'
+          - '--args=--only=terraform_typed_variables'
+          - '--args=--only=terraform_module_pinned_source'
+          - '--args=--only=terraform_naming_convention'
+          - '--args=--only=terraform_required_version'
+          - '--args=--only=terraform_required_providers'
+          - '--args=--only=terraform_standard_module_structure'
+          - '--args=--only=terraform_workspace_remote'
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -237,8 +237,8 @@ allow_github_webhooks        = true
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.69 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.34.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ allow_github_webhooks        = true
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum session duration (in seconds) for ecs task execution role. Default is 3600. | `number` | `null` | no |
 | <a name="input_mount_points"></a> [mount\_points](#input\_mount\_points) | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume`. The `readOnly` key is optional. | `list(any)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to use on all resources created (VPC, ALB, etc) | `string` | `"atlantis"` | no |
+| <a name="input_path"></a> [path](#input\_path) | If provided, all IAM roles will be created with this path. | `string` | `"/"` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | If provided, all IAM roles will be created with this permissions boundary attached. | `string` | `null` | no |
 | <a name="input_policies_arn"></a> [policies\_arn](#input\_policies\_arn) | A list of the ARN of the policies you want to apply | `list(string)` | `null` | no |
 | <a name="input_private_subnet_ids"></a> [private\_subnet\_ids](#input\_private\_subnet\_ids) | A list of IDs of existing private subnets inside the VPC | `list(string)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -237,8 +237,8 @@ allow_github_webhooks        = true
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.34.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.69 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -37,7 +37,7 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.69 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.11.0 |
 
 ## Modules
 

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -37,7 +37,7 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.11.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.69 |
 
 ## Modules
 

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -77,6 +77,8 @@ module "atlantis" {
 
   # Trusted roles
   trusted_principals = ["ssm.amazonaws.com"]
+
+  # IAM role options
   permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/cloud/developer-boundary-policy"
   path = "/delegatedadmin/developer/"
 

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -77,6 +77,8 @@ module "atlantis" {
 
   # Trusted roles
   trusted_principals = ["ssm.amazonaws.com"]
+  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/cloud/developer-boundary-policy"
+  path = "/delegatedadmin/developer/"
 
   # Atlantis
   atlantis_github_user       = var.github_user

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -80,7 +80,7 @@ module "atlantis" {
 
   # IAM role options
   permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/cloud/developer-boundary-policy"
-  path = "/delegatedadmin/developer/"
+  path                 = "/delegatedadmin/developer/"
 
   # Atlantis
   atlantis_github_user       = var.github_user

--- a/main.tf
+++ b/main.tf
@@ -454,7 +454,7 @@ resource "aws_efs_file_system" "this" {
 resource "aws_efs_mount_target" "this" {
   # we coalescelist in order to specify the resource keys when we create the subnets using the VPC or they're specified for us.  This works around the for_each value depends on attributes which can't be determined until apply error
   for_each = {
-    for k, v in zipmap(coalescelist(var.private_subnets, var.private_subnet_ids), local.private_subnet_ids) : k => v
+    for k, v in zipmap(coalescelist(var.private_subnets, var.private_subnet_ids, [""]), local.private_subnet_ids) : k => v
     if var.enable_ephemeral_storage == false
   }
 

--- a/main.tf
+++ b/main.tf
@@ -534,6 +534,7 @@ resource "aws_iam_role" "ecs_task_execution" {
   assume_role_policy   = data.aws_iam_policy_document.ecs_tasks.json
   max_session_duration = var.max_session_duration
   permissions_boundary = var.permissions_boundary
+  path                 = var.path
 
   tags = local.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -305,6 +305,12 @@ variable "permissions_boundary" {
   default     = null
 }
 
+variable "path" {
+  description = "If provided, all IAM roles will be created with this path."
+  type        = string
+  default     = "/"
+}
+
 variable "policies_arn" {
   description = "A list of the ARN of the policies you want to apply"
   type        = list(string)


### PR DESCRIPTION
## Description
Add `path` variable to main.tf for resource `aws_iam_role.ecs_task_execution` to allow for creating this role under more than the default path `/`

## Motivation and Context
This resolves an issue for accounts that don't allow creation of roles under the default "/" path. Like permissions_boundary the path is needed if governance rules only allow IAM role creation under `/mycustomrole/path/`

```# module.atlantis.aws_iam_role.ecs_task_execution will be created
  + resource "aws_iam_role" "ecs_task_execution" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = [
                              + "ssm.amazonaws.com",
                              + "ecs-tasks.amazonaws.com",
                            ]
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "atlantis-ecs-ecs_task_execution"
      + name_prefix           = (known after apply)
      + path                  = "/delegatedadmin/developer/"
      + permissions_boundary  = "arn:aws:iam::<redacted>:policy/cloud/developer-boundary-policy"
      + tags                  = {
          + "Environment" = "dev"
          + "Name"        = "atlantis-ecs"
          + "Owner"       = "myself"
        }
      + tags_all              = {
          + "Environment" = "dev"
          + "Name"        = "atlantis-ecs"
          + "Owner"       = "myself"
        }
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }
```

## Breaking Changes
No

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
