### PR TITLE
fix: Remove unneeded ingress for EFS traffic from the entire VPC

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -400,7 +400,6 @@ module "efs_sg" {
   vpc_id      = local.vpc_id
   description = "Security group allowing access to the EFS storage"
 
-  ingress_cidr_blocks = [var.cidr]
   ingress_with_source_security_group_id = [{
     rule                     = "nfs-tcp",
     source_security_group_id = module.atlantis_sg.security_group_id


### PR DESCRIPTION
## Description
Removes the unnecessary VPC-wide ingress rule for using Atlantis with EFS. I've confirmed that the [ingress rule from the Atlantis Security Group](https://github.com/terraform-aws-modules/terraform-aws-atlantis/blob/master/main.tf#L404-L406) is sufficient. 

## Motivation and Context
This should also resolve https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/252

## Breaking Changes
None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
