### PR TITLE
fix: Modify to not use sg submodule do to a failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ allow_github_webhooks        = true
 | <a name="module_container_definition_bitbucket"></a> [container\_definition\_bitbucket](#module\_container\_definition\_bitbucket) | cloudposse/ecs-container-definition/aws | v0.58.1 |
 | <a name="module_container_definition_github_gitlab"></a> [container\_definition\_github\_gitlab](#module\_container\_definition\_github\_gitlab) | cloudposse/ecs-container-definition/aws | v0.58.1 |
 | <a name="module_ecs"></a> [ecs](#module\_ecs) | terraform-aws-modules/ecs/aws | v3.3.0 |
-| <a name="module_efs_sg"></a> [efs\_sg](#module\_efs\_sg) | terraform-aws-modules/security-group/aws//modules/nfs | v4.8.0 |
+| <a name="module_efs_sg"></a> [efs\_sg](#module\_efs\_sg) | terraform-aws-modules/security-group/aws | v4.8.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | v3.6.0 |
 
 ## Resources

--- a/main.tf
+++ b/main.tf
@@ -392,7 +392,7 @@ module "atlantis_sg" {
 }
 
 module "efs_sg" {
-  source  = "terraform-aws-modules/security-group/aws//modules/nfs"
+  source  = "terraform-aws-modules/security-group/aws"
   version = "v4.8.0"
   count   = var.enable_ephemeral_storage ? 0 : 1
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Do not use `terraform-aws-modules/terraform-aws-security-group` submodule with the `ingress_with_source_security_group_id`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Fix #320 
* The issues have been reported for the `terraform-aws-modules/terraform-aws-security-group` when used with the `ingress_with_source_security_group_id`.
* It is reported that this can be avoided by not using submodules.
    * https://github.com/terraform-aws-modules/terraform-aws-security-group/issues/193#issuecomment-874081213

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
