### PR TITLE
feat: Use base security-group module to remove duplicate EFS security group

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ allow_github_webhooks        = true
 | <a name="module_container_definition_bitbucket"></a> [container\_definition\_bitbucket](#module\_container\_definition\_bitbucket) | cloudposse/ecs-container-definition/aws | v0.58.1 |
 | <a name="module_container_definition_github_gitlab"></a> [container\_definition\_github\_gitlab](#module\_container\_definition\_github\_gitlab) | cloudposse/ecs-container-definition/aws | v0.58.1 |
 | <a name="module_ecs"></a> [ecs](#module\_ecs) | terraform-aws-modules/ecs/aws | v3.3.0 |
-| <a name="module_efs_sg"></a> [efs\_sg](#module\_efs\_sg) | terraform-aws-modules/security-group/aws//modules/nfs | v4.8.0 |
+| <a name="module_efs_sg"></a> [efs\_sg](#module\_efs\_sg) | terraform-aws-modules/security-group/aws | v4.8.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | v3.6.0 |
 
 ## Resources

--- a/main.tf
+++ b/main.tf
@@ -392,7 +392,7 @@ module "atlantis_sg" {
 }
 
 module "efs_sg" {
-  source  = "terraform-aws-modules/security-group/aws//modules/nfs"
+  source  = "terraform-aws-modules/security-group/aws"
   version = "v4.8.0"
   count   = var.enable_ephemeral_storage ? 0 : 1
 


### PR DESCRIPTION
## Description
Attempt to resolve https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/324. I believe this is due to the fact that the nfs submodule is trying to create a duplicate NFS ingress that conflicts with the one defined [here](https://github.com/terraform-aws-modules/terraform-aws-atlantis/blob/master/main.tf#L403-L406). This PR used the base `security-group` module and relies on 

```hcl
  ingress_with_source_security_group_id = [{
    rule                     = "nfs-tcp",
    source_security_group_id = module.atlantis_sg.security_group_id
  }]
```

to configure the efs ingress rules. 

## Motivation and Context
Resolves https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/324

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
This will cause a brief breakage for atlantis as it will replace security groups due to the need to switch modules. A sample plan looks like the following

<details>
  <summary>Terraform plan</summary>

```
Terraform will perform the following actions:

  # module.atlantis.aws_efs_mount_target.this["10.20.1.0/24"] will be updated in-place
  ~ resource "aws_efs_mount_target" "this" {
        id                     = "fsmt-0c8334429c735571a"
      ~ security_groups        = [
          - "sg-023aee2b50991fd4b",
          - "sg-05e25a6addebd0f3f",
        ] -> (known after apply)
        # (10 unchanged attributes hidden)
    }

  # module.atlantis.aws_efs_mount_target.this["10.20.2.0/24"] will be updated in-place
  ~ resource "aws_efs_mount_target" "this" {
        id                     = "fsmt-0d40f94760fb56788"
      ~ security_groups        = [
          - "sg-023aee2b50991fd4b",
          - "sg-05e25a6addebd0f3f",
        ] -> (known after apply)
        # (10 unchanged attributes hidden)
    }

  # module.atlantis.aws_efs_mount_target.this["10.20.3.0/24"] will be updated in-place
  ~ resource "aws_efs_mount_target" "this" {
        id                     = "fsmt-0316cf50969125693"
      ~ security_groups        = [
          - "sg-023aee2b50991fd4b",
          - "sg-05e25a6addebd0f3f",
        ] -> (known after apply)
        # (10 unchanged attributes hidden)
    }

  # module.atlantis.module.efs_sg[0].aws_security_group.this_name_prefix[0] will be created
  + resource "aws_security_group" "this_name_prefix" {
      + arn                    = (known after apply)
      + description            = "Security group allowing access to the EFS storage"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = (known after apply)
      + name_prefix            = "atlantis-efs-"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "atlantis"
        }
      + tags_all               = {
          + "Automation" = "Terraform"
          + "Name"       = "atlantis"
        }
      + vpc_id                 = "vpc-079a13d42c60e2b9e"

      + timeouts {
          + create = "10m"
          + delete = "15m"
        }
    }

  # module.atlantis.module.efs_sg[0].aws_security_group_rule.ingress_with_source_security_group_id[0] will be created
  + resource "aws_security_group_rule" "ingress_with_source_security_group_id" {
      + description              = "Ingress Rule"
      + from_port                = 2049
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = "sg-05e25a6addebd0f3f"
      + to_port                  = 2049
      + type                     = "ingress"
    }

  # module.atlantis.module.efs_sg[0].module.sg.aws_security_group.this_name_prefix[0] will be destroyed
  # (because aws_security_group.this_name_prefix is not in configuration)
  - resource "aws_security_group" "this_name_prefix" {
      - arn                    = "arn:aws:ec2:us-west-2:147093333562:security-group/sg-023aee2b50991fd4b" -> null
      - description            = "Security group allowing access to the EFS storage" -> null
      - egress                 = [
          - {
              - cidr_blocks      = [
                  - "0.0.0.0/0",
                ]
              - description      = "All protocols"
              - from_port        = 0
              - ipv6_cidr_blocks = [
                  - "::/0",
                ]
              - prefix_list_ids  = []
              - protocol         = "-1"
              - security_groups  = []
              - self             = false
              - to_port          = 0
            },
        ] -> null
      - id                     = "sg-023aee2b50991fd4b" -> null
      - ingress                = [
          - {
              - cidr_blocks      = []
              - description      = "Ingress Rule"
              - from_port        = 0
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "-1"
              - security_groups  = []
              - self             = true
              - to_port          = 0
            },
          - {
              - cidr_blocks      = []
              - description      = "Ingress Rule"
              - from_port        = 2049
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "tcp"
              - security_groups  = [
                  - "sg-05e25a6addebd0f3f",
                ]
              - self             = false
              - to_port          = 2049
            },
        ] -> null
      - name                   = "atlantis-efs-20221115182547572900000005" -> null
      - name_prefix            = "atlantis-efs-" -> null
      - owner_id               = "147093333562" -> null
      - revoke_rules_on_delete = false -> null
      - tags                   = {
          - "Name" = "atlantis"
        } -> null
      - tags_all               = {
          - "Automation" = "Terraform"
          - "Name"       = "atlantis"
        } -> null
      - vpc_id                 = "vpc-079a13d42c60e2b9e" -> null

      - timeouts {
          - create = "10m" -> null
          - delete = "15m" -> null
        }
    }

  # module.atlantis.module.efs_sg[0].module.sg.aws_security_group_rule.egress_rules[0] will be destroyed
  # (because aws_security_group_rule.egress_rules is not in configuration)
  - resource "aws_security_group_rule" "egress_rules" {
      - cidr_blocks       = [
          - "0.0.0.0/0",
        ] -> null
      - description       = "All protocols" -> null
      - from_port         = 0 -> null
      - id                = "sgrule-4171184799" -> null
      - ipv6_cidr_blocks  = [
          - "::/0",
        ] -> null
      - prefix_list_ids   = [] -> null
      - protocol          = "-1" -> null
      - security_group_id = "sg-023aee2b50991fd4b" -> null
      - self              = false -> null
      - to_port           = 0 -> null
      - type              = "egress" -> null
    }

  # module.atlantis.module.efs_sg[0].module.sg.aws_security_group_rule.ingress_rules[0] will be destroyed
  # (because aws_security_group_rule.ingress_rules is not in configuration)
  - resource "aws_security_group_rule" "ingress_rules" {
      - cidr_blocks       = [] -> null
      - from_port         = 2049 -> null
      - id                = "sgrule-1299490025" -> null
      - ipv6_cidr_blocks  = [] -> null
      - prefix_list_ids   = [] -> null
      - protocol          = "tcp" -> null
      - security_group_id = "sg-023aee2b50991fd4b" -> null
      - self              = false -> null
      - to_port           = 2049 -> null
      - type              = "ingress" -> null
    }

  # module.atlantis.module.efs_sg[0].module.sg.aws_security_group_rule.ingress_with_self[0] will be destroyed
  # (because aws_security_group_rule.ingress_with_self is not in configuration)
  - resource "aws_security_group_rule" "ingress_with_self" {
      - description       = "Ingress Rule" -> null
      - from_port         = 0 -> null
      - id                = "sgrule-1227184360" -> null
      - prefix_list_ids   = [] -> null
      - protocol          = "-1" -> null
      - security_group_id = "sg-023aee2b50991fd4b" -> null
      - self              = true -> null
      - to_port           = 0 -> null
      - type              = "ingress" -> null
    }

  # module.atlantis.module.efs_sg[0].module.sg.aws_security_group_rule.ingress_with_source_security_group_id[0] will be destroyed
  # (because aws_security_group_rule.ingress_with_source_security_group_id is not in configuration)
  - resource "aws_security_group_rule" "ingress_with_source_security_group_id" {
      - description              = "Ingress Rule" -> null
      - from_port                = 2049 -> null
      - id                       = "sgrule-2156250272" -> null
      - prefix_list_ids          = [] -> null
      - protocol                 = "tcp" -> null
      - security_group_id        = "sg-023aee2b50991fd4b" -> null
      - self                     = false -> null
      - source_security_group_id = "sg-05e25a6addebd0f3f" -> null
      - to_port                  = 2049 -> null
      - type                     = "ingress" -> null
    }

Plan: 2 to add, 3 to change, 5 to destroy.
``` 

</details>

I wasn't able to find a way to fix this without this breaking change, but let me know if there's another avenue to go down.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
