### PR TITLE
feat: Add profile and region variables

### DIFF
--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -1,5 +1,5 @@
 locals {
-  name   = "atlantis"
+  name   = "github-complete"
   region = var.region
 
   tags = {

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -1,10 +1,6 @@
-provider "aws" {
-  region = local.region
-}
-
 locals {
-  name   = "github-complete"
-  region = "eu-west-1"
+  name   = "atlantis"
+  region = var.region
 
   tags = {
     Owner       = "user"

--- a/terraform.tfvars.sample
+++ b/terraform.tfvars.sample
@@ -9,7 +9,7 @@ vpc_id = ""
 private_subnet_ids = ["", ""]
 public_subnet_ids = ["", ""]
 
-region = "us-east-1"
+region = "eu-west-1"
 profile = "default"
 
 # DNS

--- a/terraform.tfvars.sample
+++ b/terraform.tfvars.sample
@@ -1,16 +1,16 @@
 # VPC - use these parameters to create new VPC resources
-cidr = "10.10.0.0/16"
-
-azs = ["eu-west-1a", "eu-west-1b"]
-
-private_subnets = ["10.10.1.0/24", "10.10.2.0/24"]
-
-public_subnets = ["10.10.11.0/24", "10.10.12.0/24"]
+# cidr = "10.10.0.0/16"
+# azs = ["eu-west-1a", "eu-west-1b"]
+# private_subnets = ["10.10.1.0/24", "10.10.2.0/24"]
+# public_subnets = ["10.10.11.0/24", "10.10.12.0/24"]
 
 # VPC - use these parameters to use existing VPC resources
-# vpc_id = "vpc-1651acf1"
-# private_subnet_ids = ["subnet-1fe3d837", "subnet-129d66ab"]
-# public_subnet_ids = ["subnet-1211eef5", "subnet-163466ab"]
+vpc_id = ""
+private_subnet_ids = ["", ""]
+public_subnet_ids = ["", ""]
+
+region = "us-east-1"
+profile = "default"
 
 # DNS
 route53_zone_name = "example.com"
@@ -27,8 +27,16 @@ atlantis_repo_allowlist = ["github.com/terraform-aws-modules/*"]
 
 # Specify one of the following block.
 # For Github
-atlantis_github_user = ""
-atlantis_github_user_token = ""
+# atlantis_github_user = ""
+# atlantis_github_user_token = ""
+atlantis_github_app_id = ""
+atlantis_github_org = ""
+atlantis_github_app_key = <<EOT
+# Add private key here
+# starting with
+# -----BEGIN RSA PRIVATE KEY-----
+EOT
+
 
 # For Gitlab
 atlantis_gitlab_user = ""

--- a/terraform.tfvars.sample
+++ b/terraform.tfvars.sample
@@ -26,9 +26,11 @@ ecs_service_assign_public_ip = true
 atlantis_repo_allowlist = ["github.com/terraform-aws-modules/*"]
 
 # Specify one of the following block.
-# For Github
+# For Github (personal)
 # atlantis_github_user = ""
 # atlantis_github_user_token = ""
+
+# For Github (organization with Github app)
 atlantis_github_app_id = ""
 atlantis_github_org = ""
 atlantis_github_app_key = <<EOT

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,18 @@ variable "cidr" {
   default     = ""
 }
 
+variable "region" {
+  description = "The region where resources will be created"
+  type        = string
+  default     = ""
+}
+
+variable "profile" {
+  description = "The AWS profile to which will be used in creating resources"
+  type        = string
+  default     = "default"
+}
+
 variable "azs" {
   description = "A list of availability zones in the region"
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -68,7 +68,7 @@ variable "cidr" {
 variable "region" {
   description = "The region where resources will be created"
   type        = string
-  default     = ""
+  default     = "eu-west-1"
 }
 
 variable "profile" {

--- a/versions.tf
+++ b/versions.tf
@@ -13,3 +13,8 @@ terraform {
     }
   }
 }
+
+provider "aws" {
+  profile = var.profile
+  region = var.region
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This change adds profile and region variables so that the user can specify which AWS account on their machine they would like to use. It also updates the `terraform.tfvars.sample` to include variables for using GitHub apps instead of Personal Access Tokens.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A user may have more than one AWS account and would like to use either. This change allows them to specify which AWS profile to use, other than the `default` profile.
It also allows you to specify a region rather than hard-coding it. If no region is specified, the original hard-coded region has been made the default.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
