### PR TITLE
feat: Adds efs throughput option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -466,6 +466,11 @@ resource "aws_efs_file_system" "this" {
   creation_token = coalesce(var.efs_file_system_token, var.name)
 
   encrypted = var.efs_file_system_encrypted
+
+  provisioned_throughput_in_mibps = var.efs_file_system_provisioned_throughput_in_mibps
+  throughput_mode                 = var.efs_file_system_throughput_mode
+
+  tags = local.tags
 }
 
 resource "aws_efs_mount_target" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -743,6 +743,18 @@ variable "efs_file_system_token" {
   default     = ""
 }
 
+variable "efs_file_system_throughput_mode" {
+  description = "Throughput mode for the file system. Valid values: bursting, provisioned, or elastic. Defaults to bursting. When using provisioned, also set efs_file_system_provisioned_throughput_in_mibps."
+  type        = string
+  default     = "bursting"
+}
+
+variable "efs_file_system_provisioned_throughput_in_mibps" {
+  description = "Optional) The throughput, measured in MiB/s, that you want to provision for the file system. Only applicable with efs_file_system_throughput_mode set to provisioned."
+  type        = number
+  default     = null
+}
+
 variable "alb_ip_address_type" {
   description = "The type of IP addresses used by the subnets for your load balancer. The possible values are ipv4 and dualstack"
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.69"
+      version = ">= 4.42"
     }
 
     random = {


### PR DESCRIPTION
## Description
- Adds `provisioned_throughput_in_mibps`, `throughput_mode`, and `tags` inputs to the `aws_efs_file_system.this` resource

## Motivation and Context
I'd like to be able to set the `throughput_mode = "elastic"` option on the efs volume managed by this module.

## Breaking Changes
- the elastic throughput mode was not made available until v4.42 of the aws provider. If there is a preference to keep this module backwards compatible with 3.69 I can just set the provider version in my module's instantiation. 

## How Has This Been Tested?
- [x] deployed this branch against a working implementation
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
