### PR TITLE
fix: Gitlab versioning errors with terraform 0.13

### DIFF
--- a/examples/gitlab-repository-webhook/README.md
+++ b/examples/gitlab-repository-webhook/README.md
@@ -21,7 +21,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.45 |
-| <a name="requirement_gitlab"></a> [gitlab](#requirement\_gitlab) | >= 3.0 |
+| <a name="requirement_gitlab"></a> [gitlab](#requirement\_gitlab) | 3.20.0 |
 
 ## Providers
 

--- a/examples/gitlab-repository-webhook/versions.tf
+++ b/examples/gitlab-repository-webhook/versions.tf
@@ -8,8 +8,9 @@ terraform {
     }
 
     gitlab = {
+      # gitlab provider requires terraform 1.0 or later starting in 15.x.x
       source  = "gitlabhq/gitlab"
-      version = ">= 3.0"
+      version = "3.20.0"
     }
   }
 }

--- a/modules/gitlab-repository-webhook/README.md
+++ b/modules/gitlab-repository-webhook/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_gitlab"></a> [gitlab](#requirement\_gitlab) | >= 3.0 |
+| <a name="requirement_gitlab"></a> [gitlab](#requirement\_gitlab) | 3.20.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_gitlab"></a> [gitlab](#provider\_gitlab) | >= 3.0 |
+| <a name="provider_gitlab"></a> [gitlab](#provider\_gitlab) | 3.20.0 |
 
 ## Modules
 
@@ -22,7 +22,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [gitlab_project_hook.this](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_hook) | resource |
+| [gitlab_project_hook.this](https://registry.terraform.io/providers/gitlabhq/gitlab/3.20.0/docs/resources/project_hook) | resource |
 
 ## Inputs
 

--- a/modules/gitlab-repository-webhook/versions.tf
+++ b/modules/gitlab-repository-webhook/versions.tf
@@ -3,8 +3,9 @@ terraform {
 
   required_providers {
     gitlab = {
-      source  = "gitlabhq/gitlab"
-      version = ">= 3.0"
+      source = "gitlabhq/gitlab"
+      # gitlab provider requires terraform 1.0 or later starting in 15.x.x
+      version = "3.20.0"
     }
   }
 }


### PR DESCRIPTION
## Description
This will hopefully fix the pre-commit issues popping up in https://github.com/terraform-aws-modules/terraform-aws-atlantis/pull/343

## Motivation and Context
To fix broken pre-commits

## Breaking Changes
None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
