### PR TITLE
fix: Set AWS provider version constraint to less than 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,14 +265,14 @@ allow_github_webhooks        = true
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.69 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.69, < 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.69 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.69, < 5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.69"
+      version = ">= 3.69, < 5.0"
     }
 
     random = {


### PR DESCRIPTION
## Description
Setting AWS provider constraint to less than v5.0

## Motivation and Context
When the provider version resolves to v5.0 there are a lot of unsupported arguments and blocks:
```
 Warning: Argument is deprecated
│ 
│   with module.vpc.aws_eip.nat,
│   on .terraform/modules/vpc/main.tf line 1068, in resource "aws_eip" "nat":
│ 1068:   vpc = true
│ 
│ use domain attribute instead
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 593, in data "aws_iam_policy_document" "ecs_task_access_secrets_with_kms":
│  593:   source_json = data.aws_iam_policy_document.ecs_task_access_secrets.json
│ 
│ An argument named "source_json" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on .terraform/modules/ecs/main.tf line 6, in resource "aws_ecs_cluster" "this":
│    6:   capacity_providers = var.capacity_providers
│ 
│ An argument named "capacity_providers" is not expected here.
╵
╷
│ Error: Unsupported block type
│ 
│   on .terraform/modules/ecs/main.tf line 8, in resource "aws_ecs_cluster" "this":
│    8:   dynamic "default_capacity_provider_strategy" {
│ 
│ Blocks of type "default_capacity_provider_strategy" are not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on .terraform/modules/vpc/main.tf line 32, in resource "aws_vpc" "this":
│   32:   enable_classiclink               = var.enable_classiclink
│ 
│ An argument named "enable_classiclink" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on .terraform/modules/vpc/main.tf line 33, in resource "aws_vpc" "this":
│   33:   enable_classiclink_dns_support   = var.enable_classiclink_dns_support
│ 
│ An argument named "enable_classiclink_dns_support" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on .terraform/modules/vpc/main.tf line 1307, in resource "aws_default_vpc" "this":
│ 1307:   enable_classiclink   = var.default_vpc_enable_classiclink
│ 
│ An argument named "enable_classiclink" is not expected here.
```
With the locked version it resolves this issue and the plan passes again.

## Breaking Changes

No

## How Has This Been Tested?

- [ ] I have updated at least one of the examples/* to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided examples/* projects
- [x] I have executed pre-commit run -a on my pull request