### PR TITLE
fix: Pin aws provider version prior to 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,14 +265,14 @@ allow_github_webhooks        = true
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.69 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.69, <5.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.69 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.69, <5.0.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -36,14 +36,14 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.69 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.69, <5.0.0 |
 | <a name="requirement_github"></a> [github](#requirement\_github) | >= 4.8 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.69 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.69, <5.0.0 |
 
 ## Modules
 

--- a/examples/github-complete/versions.tf
+++ b/examples/github-complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.69"
+      version = ">= 3.69, <5.0.0"
     }
 
     github = {

--- a/examples/github-repository-webhook/README.md
+++ b/examples/github-repository-webhook/README.md
@@ -22,7 +22,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.45 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.69, <5.0.0 |
 | <a name="requirement_github"></a> [github](#requirement\_github) | >= 4.8 |
 
 ## Providers

--- a/examples/github-repository-webhook/versions.tf
+++ b/examples/github-repository-webhook/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.45"
+      version = ">= 3.69, <5.0.0"
     }
 
     github = {

--- a/examples/gitlab-repository-webhook/README.md
+++ b/examples/gitlab-repository-webhook/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.45 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.69, <5.0.0 |
 | <a name="requirement_gitlab"></a> [gitlab](#requirement\_gitlab) | 3.20.0 |
 
 ## Providers

--- a/examples/gitlab-repository-webhook/versions.tf
+++ b/examples/gitlab-repository-webhook/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.45"
+      version = ">= 3.69, <5.0.0"
     }
 
     gitlab = {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.69"
+      version = ">= 3.69, <5.0.0"
     }
 
     random = {


### PR DESCRIPTION
## Description

As mentioned in #349 some modules used in current version of the module (`v3.28.0`) are not compatible with latest aws-provider. To fix it we have to adjust module requirments.

## Motivation and Context
- Fix CI - currently GitHub actions are reporting errors like this:
```
Validation failed: .
╷
│ Warning: Argument is deprecated
│ 
│   with module.vpc.aws_eip.nat,
│   on .terraform/modules/vpc/main.tf line 10[68](https://github.com/terraform-aws-modules/terraform-aws-atlantis/actions/runs/5867579962/job/15908553795#step:4:72), in resource "aws_eip" "nat":
│ 1068:   vpc = true
│ 
│ use domain attribute instead
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 597, in data "aws_iam_policy_document" "ecs_task_access_secrets_with_kms":
│  597:   source_json = data.aws_iam_policy_document.ecs_task_access_secrets.json
│ 
│ An argument named "source_json" is not expected here.
╵
```
Ref: https://github.com/terraform-aws-modules/terraform-aws-atlantis/actions/runs/5867579962/job/15908553795

## Breaking Changes
- There is no breaking changes, but this change will prevent any further updated of aws provider `v5.0+`

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
