### PR TITLE
fix: Add `validate_certificate` variable in atlantis module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -416,7 +416,8 @@ module "acm" {
   source  = "terraform-aws-modules/acm/aws"
   version = "v3.2.0"
 
-  create_certificate = var.certificate_arn == ""
+  create_certificate   = var.certificate_arn == ""
+  validate_certificate = var.validate_certificate
 
   domain_name = var.acm_certificate_domain_name == "" ? join(".", [var.name, var.route53_zone_name]) : var.acm_certificate_domain_name
 

--- a/main.tf
+++ b/main.tf
@@ -210,7 +210,7 @@ resource "aws_ssm_parameter" "atlantis_github_app_key" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "v3.6.0"
+  version = "v3.19.0"
 
   create_vpc = var.vpc_id == ""
 
@@ -508,7 +508,7 @@ resource "aws_efs_access_point" "this" {
 ################################################################################
 module "ecs" {
   source  = "terraform-aws-modules/ecs/aws"
-  version = "v3.3.0"
+  version = "v3.5.0"
 
   create_ecs = var.create_ecs_cluster
 
@@ -591,7 +591,7 @@ data "aws_iam_policy_document" "ecs_task_access_secrets" {
 data "aws_iam_policy_document" "ecs_task_access_secrets_with_kms" {
   count = var.ssm_kms_key_arn == "" ? 0 : 1
 
-  source_json = data.aws_iam_policy_document.ecs_task_access_secrets.json
+  source_policy_documents = [ data.aws_iam_policy_document.ecs_task_access_secrets.json ]
 
   statement {
     sid       = "AllowKMSDecrypt"

--- a/variables.tf
+++ b/variables.tf
@@ -229,6 +229,12 @@ variable "certificate_arn" {
   default     = ""
 }
 
+variable "validate_certificate" {
+  description = "Whether to validate certificate by creating Route53 record"
+  type        = bool
+  default     = true
+}
+
 variable "acm_certificate_domain_name" {
   description = "Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance. Specify if it is different from value in `route53_zone_name`"
   type        = string


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Add the option to set the `validate_certificate` variable as part of the acm module. This variable will trigger the creation of a route53 record to validate the certificate ownership.

Allowing to disable this variable is useful when using external DNS (not route53).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/360

I decided to add a new variable, and not set `validate_certificate = var.create_route53_record || var.create_route53_aaaa_record` to not introduce a breaking change.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

This is not a breaking change.
The value added is default to `true` in the `acm` module, and I defaulted to `true` in the atlantis module.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
- [X] I have tested and validated these changes using my own deployment
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
