### PR TITLE
fix: Separate Repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ crash.log
 # password, private keys, and other secrets. These should not be part of version
 # control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
-*.tfvars
+# *.tfvars
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 locals {
   name   = "github-complete"
-  region = "eu-west-1"
+  region = "us-east-1"
 
   tags = {
     Owner       = "user"

--- a/main.tf
+++ b/main.tf
@@ -164,15 +164,19 @@ resource "aws_ssm_parameter" "webhook" {
   tags = local.tags
 }
 
-resource "aws_ssm_parameter" "atlantis_github_user_token" {
-  count = var.atlantis_github_user_token != "" ? 1 : 0
+## Moved to devios-secret-parameters repo.
+# resource "aws_ssm_parameter" "atlantis_github_user_token" {
+#   count = var.atlantis_github_user_token != "" ? 1 : 0
 
-  name  = var.atlantis_github_user_token_ssm_parameter_name
-  type  = "SecureString"
-  value = var.atlantis_github_user_token
-
-  tags = local.tags
-}
+#   name  = var.atlantis_github_user_token_ssm_parameter_name
+#   type  = "SecureString"
+#   value = var.atlantis_github_user_token
+#   lifecycle {
+#     prevent_destroy  = false
+#   }
+  
+#   tags = local.tags
+# }
 
 resource "aws_ssm_parameter" "atlantis_gitlab_user_token" {
   count = var.atlantis_gitlab_user_token != "" ? 1 : 0
@@ -571,14 +575,23 @@ data "aws_iam_policy_document" "ecs_task_access_secrets" {
   statement {
     effect = "Allow"
 
+    # resources = flatten([
+    #   aws_ssm_parameter.webhook[*].arn,
+    #   aws_ssm_parameter.atlantis_github_user_token[*].arn,
+    #   aws_ssm_parameter.atlantis_gitlab_user_token[*].arn,
+    #   aws_ssm_parameter.atlantis_bitbucket_user_token[*].arn,
+    #   aws_ssm_parameter.atlantis_github_app_key[*].arn,
+    #   try(var.repository_credentials["credentialsParameter"], [])
+    # ])
+
     resources = flatten([
       aws_ssm_parameter.webhook[*].arn,
-      aws_ssm_parameter.atlantis_github_user_token[*].arn,
+      "arn:aws:ssm:us-east-1:353472581086:parameter/dev/atlantis-fargate/TOKEN/github-token",
       aws_ssm_parameter.atlantis_gitlab_user_token[*].arn,
       aws_ssm_parameter.atlantis_bitbucket_user_token[*].arn,
       aws_ssm_parameter.atlantis_github_app_key[*].arn,
       try(var.repository_credentials["credentialsParameter"], [])
-    ])
+    ])    
 
     actions = [
       "ssm:GetParameters",

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "us-east-1"
+}

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,0 +1,38 @@
+# VPC - use these parameters to create new VPC resources
+cidr = "102.10.0.0/16"
+
+azs = ["us-east-1a", "us-east-1b"]
+
+private_subnets = ["102.10.1.0/24", "102.10.2.0/24"]
+
+public_subnets = ["102.10.11.0/24", "102.10.12.0/24"]
+
+# VPC - use these parameters to use existing VPC resources
+# vpc_id = "vpc-1651acf1"
+# private_subnet_ids = ["subnet-1fe3d837", "subnet-129d66ab"]
+# public_subnet_ids = ["subnet-1211eef5", "subnet-163466ab"]
+
+# DNS
+route53_zone_name = "devops.com.ph"
+
+# ACM (SSL certificate)
+# Specify ARN of an existing certificate or new one will be created and validated using Route53 DNS:
+# certificate_arn = "arn:aws:acm:eu-west-1:135367859851:certificate/70e008e1-c0e1-4c7e-9670-7bb5bd4f5a84"
+
+# ECS Service and Task
+ecs_service_assign_public_ip = true
+
+# Atlantis
+# gitlab_base_url = ["https://github.com/devkinetics/"]
+atlantis_repo_allowlist = ["terraform-aws-atlantis", "serverless-jenkins-on-ecs","atlantis-test-repo"]
+
+# Specify one of the following block.
+# For Github
+atlantis_github_user = "mikaelvg"
+atlantis_github_user_token_ssm_parameter_name = "/dev/atlantis-fargate/TOKEN/github-token" // Created in devios-secret-parameters repo.
+webhook_ssm_parameter_name = "/dev/atlantis-fargate/SCRET/webhook-secret"  // Override the default naming convention
+
+# Tags
+tags = {
+  Name = "atlantis"
+}

--- a/terraform.tfvars.sample
+++ b/terraform.tfvars.sample
@@ -1,11 +1,11 @@
 # VPC - use these parameters to create new VPC resources
-cidr = "10.10.0.0/16"
+cidr = "102.10.0.0/16"
 
-azs = ["eu-west-1a", "eu-west-1b"]
+azs = ["us-east-1a", "us-east-1b"]
 
-private_subnets = ["10.10.1.0/24", "10.10.2.0/24"]
+private_subnets = ["102.10.1.0/24", "102.10.2.0/24"]
 
-public_subnets = ["10.10.11.0/24", "10.10.12.0/24"]
+public_subnets = ["102.10.11.0/24", "102.10.12.0/24"]
 
 # VPC - use these parameters to use existing VPC resources
 # vpc_id = "vpc-1651acf1"
@@ -13,7 +13,7 @@ public_subnets = ["10.10.11.0/24", "10.10.12.0/24"]
 # public_subnet_ids = ["subnet-1211eef5", "subnet-163466ab"]
 
 # DNS
-route53_zone_name = "example.com"
+route53_zone_name = "devops.com.ph"
 
 # ACM (SSL certificate)
 # Specify ARN of an existing certificate or new one will be created and validated using Route53 DNS:
@@ -23,23 +23,13 @@ route53_zone_name = "example.com"
 ecs_service_assign_public_ip = true
 
 # Atlantis
-atlantis_repo_allowlist = ["github.com/terraform-aws-modules/*"]
+# gitlab_base_url = ["https://github.com/devkinetics/"]
+atlantis_repo_allowlist = ["terraform-aws-atlantis"]
 
 # Specify one of the following block.
 # For Github
-atlantis_github_user = ""
-atlantis_github_user_token = ""
-
-# For Gitlab
-atlantis_gitlab_user = ""
-atlantis_gitlab_user_token = ""
-
-# For Bitbucket
-atlantis_bitbucket_user = ""
-atlantis_bitbucket_user_token = ""
-
-# For Bitbucket on prem (Stash)
-# atlantis_bitbucket_base_url = ""
+atlantis_github_user = "mikaelvg"
+atlantis_github_user_token = "ghp_xxxxx"
 
 # Tags
 tags = {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.69"
+      version = ">= 3.69, < 5.0"
     }
 
     random = {


### PR DESCRIPTION
## Description
Moved the GITHUB token codes to a different repo

## Motivation and Context
-SSM is cheap. No need to delete every spindown of servers.
-Also no need to recreate manually.
