### PR TITLE
fix: Ensure conditional creation of EFS and entire module are functioning as intended

### DIFF
--- a/examples/github-separate/README.md
+++ b/examples/github-separate/README.md
@@ -37,6 +37,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|--------|---------|
 | <a name="module_alb"></a> [alb](#module\_alb) | terraform-aws-modules/alb/aws | 9.1.0 |
 | <a name="module_atlantis"></a> [atlantis](#module\_atlantis) | ../../ | n/a |
+| <a name="module_atlantis_disabled"></a> [atlantis\_disabled](#module\_atlantis\_disabled) | ../../ | n/a |
 | <a name="module_ecs_cluster"></a> [ecs\_cluster](#module\_ecs\_cluster) | terraform-aws-modules/ecs/aws//modules/cluster | 5.6.0 |
 | <a name="module_github_repository_webhooks"></a> [github\_repository\_webhooks](#module\_github\_repository\_webhooks) | ../../modules/github-repository-webhook | n/a |
 | <a name="module_secrets_manager"></a> [secrets\_manager](#module\_secrets\_manager) | terraform-aws-modules/secrets-manager/aws | ~> 1.0 |

--- a/examples/github-separate/main.tf
+++ b/examples/github-separate/main.tf
@@ -80,22 +80,6 @@ module "atlantis" {
   service_subnets = module.vpc.private_subnets
   vpc_id          = module.vpc.vpc_id
 
-  # EFS
-  enable_efs = true
-  efs = {
-    mount_targets = {
-      "eu-west-1a" = {
-        subnet_id = module.vpc.private_subnets[0]
-      }
-      "eu-west-1b" = {
-        subnet_id = module.vpc.private_subnets[1]
-      }
-      "eu-west-1c" = {
-        subnet_id = module.vpc.private_subnets[2]
-      }
-    }
-  }
-
   tags = local.tags
 }
 
@@ -106,6 +90,12 @@ module "github_repository_webhooks" {
 
   webhook_url    = "http://${module.alb.dns_name}/events"
   webhook_secret = random_password.webhook_secret.result
+}
+
+module "atlantis_disabled" {
+  source = "../../"
+
+  create = false
 }
 
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -230,7 +230,7 @@ module "ecs_service" {
   ignore_task_definition_changes     = try(var.service.ignore_task_definition_changes, false)
   alarms                             = try(var.service.alarms, {})
   capacity_provider_strategy         = try(var.service.capacity_provider_strategy, {})
-  cluster_arn                        = var.create_cluster ? module.ecs_cluster.arn : var.cluster_arn
+  cluster_arn                        = var.create_cluster && var.create ? module.ecs_cluster.arn : var.cluster_arn
   deployment_controller              = try(var.service.deployment_controller, {})
   deployment_maximum_percent         = try(var.service.deployment_maximum_percent, 200)
   deployment_minimum_healthy_percent = try(var.service.deployment_minimum_healthy_percent, 66)
@@ -243,7 +243,7 @@ module "ecs_service" {
   load_balancer = merge(
     {
       service = {
-        target_group_arn = var.create_alb ? module.alb.target_groups["atlantis"].arn : var.alb_target_group_arn
+        target_group_arn = var.create_alb && var.create ? module.alb.target_groups["atlantis"].arn : var.alb_target_group_arn
         container_name   = "atlantis"
         container_port   = local.atlantis_port
       }
@@ -375,7 +375,7 @@ module "ecs_service" {
           file_system_id     = module.efs.id
           transit_encryption = "ENABLED"
           authorization_config = {
-            access_point_id = module.efs.access_points["atlantis"].id
+            access_point_id = try(module.efs.access_points["atlantis"].id, null)
             iam             = "ENABLED"
           }
         }


### PR DESCRIPTION
## Description
- Ensure conditional creation of EFS and entire module are functioning as intended
	- I have updated the `github-separate/` example to remove EFS support since this use case is covered by `github-complete/`, and also added a disabled module definition to ensure that disabling the module creation works as intended. These changes demonstrated the issue in #369 plus a few other issues which have been corrected

## Motivation and Context
- Resolves #369 

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	- Validated with both examples
- [x] I have executed `pre-commit run -a` on my pull request