### PR TITLE
fix: Correct security group egress rule lookup name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -139,7 +139,7 @@ module "alb" {
       }
     }
   )
-  security_group_egress_rules = lookup(var.alb, "security_group_ingress_rules",
+  security_group_egress_rules = lookup(var.alb, "security_group_egress_rules",
     {
       all = {
         ip_protocol = "-1"


### PR DESCRIPTION
## Description
- Correct security group egress rule lookup name - looks like a copy+paste typo causing ingress rules to be added to the egress rules

## Motivation and Context
- Resolves #371 

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
