### PR TITLE
Add ACM module outputs to top-level atlantis module outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -34,3 +34,12 @@ output "efs" {
   description = "EFS created and all of its associated outputs"
   value       = module.efs
 }
+
+################################################################################
+# ACM
+################################################################################
+
+output "acm" {
+  description = "ACM created and all of its associated outputs"
+  value       = module.acm
+}


### PR DESCRIPTION
## Description
Add the ACM module outputs to the top-level atlantis module outputs

## Motivation and Context
To add additional https listeners, I want to reference the ACM certificate ARN

## Breaking Changes
None

## How Has This Been Tested?
Modified locally and used as
```
module "atlantis"  {
  [...]

  alb = {
    listeners = {
      https_unauth = {
        port            = 8443
        protocol        = "HTTPS"
        ssl_policy      = "ELBSecurityPolicy-TLS13-1-2-Res-2021-06"
        certificate_arn = module.atlantis.acm.acm_certificate_arn
        forward = {
          target_group_key = "atlantis"
        }
      }
    }
   [...]
  }
  [...]
}
```