### PR TITLE
fix: Correct ALB atlantis target group protocol and port arguments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -94,8 +94,8 @@ module "alb" {
   target_groups = merge(
     {
       atlantis = {
-        backend_protocol                  = "HTTP"
-        backend_port                      = local.atlantis_port
+        protocol                          = "HTTP"
+        port                              = local.atlantis_port
         create_attachment                 = false
         target_type                       = "ip"
         deregistration_delay              = 10


### PR DESCRIPTION
Following the upgrade to Terraform ALB module major version 9, it is essential to note that the target group arguments `backend_protocol` and `backend_port` now require adjustment. Going forward, these should be replaced with `protocol` and `port` respectively.