### PR TITLE
fix: Give Atlantis write permission to EFS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -485,7 +485,7 @@ module "efs" {
   override_policy_documents          = try(var.efs.override_policy_documents, [])
   policy_statements = concat(
     [{
-      actions = ["elasticfilesystem:ClientMount"]
+      actions = ["elasticfilesystem:ClientMount", "elasticfilesystem:ClientWrite"]
       principals = [
         {
           type        = "AWS"


### PR DESCRIPTION
## Description
Add `elasticfilesystem:ClientWrite` permission to the EFS file system policy.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, we give only the mounting permission, so Atlantis ECS container can mount EFS, but cannot write anything under `/home/atlantis/*` directory. Due to this problem, Atlantis container cannot start with `enable_efs = true` option.
This is the error message I saw in the Atlantis log.
```
Error: initializing server: unable to create dir "/home/atlantis/.atlantis/bin": mkdir /home/atlantis/.atlantis: read-only file system
```

The error was solved when I added the `elasticfilesystem:ClientWrite` permission.

The current workaround is to configure efs parameter as follows:
```terraform
enable_efs = true
efs = {
  mount_targets = {
    "eu-west-1a" = {
      subnet_id = module.vpc.private_subnets[0]
    }
    ...
  }
  attach_policy = false # <= Here
}
```

## Breaking Changes
N/A

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
