### PR TITLE
fix: FQDN detection when using an existing ALB

### DIFF
--- a/examples/github-separate/main.tf
+++ b/examples/github-separate/main.tf
@@ -67,6 +67,7 @@ module "atlantis" {
         valueFrom = try(module.secrets_manager["github-webhook-secret"].secret_arn, "")
       },
     ]
+    fqdn = module.alb.dns_name
   }
 
   service = {

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,7 @@
 locals {
   # Atlantis
   atlantis_url = "https://${try(coalesce(
-    try(var.atlantis.fqdn, null),
-    module.alb.route53_records["A"].fqdn,
+    try(var.atlantis.fqdn, module.alb.route53_records["A"].fqdn, null),
     module.alb.dns_name,
   ), "")}"
 


### PR DESCRIPTION
## Description
In the definition of the local variable `atlantis_url`, currently attributes of `module.alb` are referenced within a `coalesce` function call. `coalesce` isn't short-circuiting, so even if `var.atlantis.fqdn` was provided, it won't be used in the case when an existing ALB is used: the reference to `module.alb.route53_records["A"]` will fail, and the error will be caught by the top-level `try`, leaving `atlantis_url` as `https://`.

In this change, the individual references to `module.alb` are wrapped in `try` calls, meaning that `var.atlantis.fqdn` will be respected if provided.

## Motivation and Context
This change fixes this issue: https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/377
With this change, links in the "Checks" section of a Github pull request point to the correct URL.

## Breaking Changes
This change can force replacement of the ECS task definition in the case where an existing ALB was used and `var.atlantis.fqdn` was specified (but ignored). If this is not desirable, this can be avoided by removing that variable from the configuration. I believe this is unlikely to happen.
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->

  I added the `fqdn` variable to `github-separate`, and deployed it without this change. That resulted in `ATLANTIS_ATLANTIS_URL` being set to `https://`. Then I ran `terraform apply` with this change. That resulted in `module.atlantis.module.ecs_service.aws_ecs_task_definition.this[0]` being recreated and `ATLANTIS_ATLANTIS_URL` being set to the URL of the load balancer.
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

