### PR TITLE
fix: Add 'Name' Tag to EFS File System

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -466,6 +466,7 @@ module "efs" {
   version = "1.3.1"
 
   create = var.create && var.enable_efs
+  name   = var.name
 
   # File system
   availability_zone_name          = try(var.efs.availability_zone_name, null)


### PR DESCRIPTION
## Description

Add `name = var.name` property to the EFS module. This value is added as a tag to the EFS file system by the EFS module.

## Motivation and Context

- Fixes #386 

## How Has This Been Tested?
- [x] I have tested this on my own configuration
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
