### PR TITLE
fix: Add ALB Target Group Name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -93,6 +93,7 @@ module "alb" {
   target_groups = merge(
     {
       atlantis = {
+        name                              = var.name
         protocol                          = "HTTP"
         port                              = local.atlantis_port
         create_attachment                 = false


### PR DESCRIPTION
## Description

Add `name = var.name` property to the ALB module `target_groups.atlantis` block.

## Motivation and Context

- Fixes #388 

## Breaking Changes

This will cause any currently created ALB target group to be deleted and recreated with the new name and the ALB listener and ECS service will be updated.

## How Has This Been Tested?
- [x] I have tested this on my own configuration
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
