### PR TITLE
feat: Configurable default action https listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alb"></a> [alb](#input\_alb) | Map of values passed to ALB module definition. See the [ALB module](https://github.com/terraform-aws-modules/terraform-aws-alb) for full list of arguments supported | `any` | `{}` | no |
+| <a name="input_alb_https_default_action"></a> [alb\_https\_default\_action](#input\_alb\_https\_default\_action) | Default action for the ALB https listener | `any` | <pre>{<br>  "forward": {<br>    "target_group_key": "atlantis"<br>  }<br>}</pre> | no |
 | <a name="input_alb_security_group_id"></a> [alb\_security\_group\_id](#input\_alb\_security\_group\_id) | ID of an existing security group that will be used by ALB. Required if `create_alb` is `false` | `string` | `""` | no |
 | <a name="input_alb_subnets"></a> [alb\_subnets](#input\_alb\_subnets) | List of subnets to place ALB in. Required if `create_alb` is `true` | `list(string)` | `[]` | no |
 | <a name="input_alb_target_group_arn"></a> [alb\_target\_group\_arn](#input\_alb\_target\_group\_arn) | ARN of an existing ALB target group that will be used to route traffic to the Atlantis service. Required if `create_alb` is `false` | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -78,11 +78,8 @@ module "alb" {
           protocol        = "HTTPS"
           ssl_policy      = try(var.alb.https_listener_ssl_policy, "ELBSecurityPolicy-TLS13-1-2-Res-2021-06")
           certificate_arn = var.create_certificate ? module.acm.acm_certificate_arn : var.certificate_arn
-
-          forward = {
-            target_group_key = "atlantis"
-          }
         },
+        var.alb_https_default_action,
         lookup(var.alb, "https_listener", {})
       )
     },

--- a/variables.tf
+++ b/variables.tf
@@ -68,6 +68,16 @@ variable "alb" {
   default     = {}
 }
 
+variable "alb_https_default_action" {
+  description = "Default action for the ALB https listener"
+  type        = any
+  default = {
+    forward = {
+      target_group_key = "atlantis"
+    }
+  }
+}
+
 variable "alb_subnets" {
   description = "List of subnets to place ALB in. Required if `create_alb` is `true`"
   type        = list(string)


### PR DESCRIPTION
Make the ALB https listener default action configurable

## Description

This PR adds a new variable `alb_https_default_action` that allows configuring the default action for the ALB https listener.

## Motivation and Context

In my scenario, I wanted the default action to be a blocking one (send a fixed response instead of forwarding to Atlantis target group).

The reason for it is that I'm adding a rule that grants access through OIDC Authentication, but for that to make sense I need to have a default rule that doesn't forward.

Currently, this default action is hardcoded so this PR adds a variable to allow overriding it.

## Breaking Changes

No breaking change, the new variable defaults to the value that preserves current behaviour

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
