### PR TITLE
feat: Add support for different name for EFS 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -467,7 +467,7 @@ module "efs" {
   version = "1.3.1"
 
   create = var.create && var.enable_efs
-  name   = var.name
+  name   = try(var.efs.name, var.name)
 
   # File system
   availability_zone_name          = try(var.efs.availability_zone_name, null)


### PR DESCRIPTION
## Description
The logic to name EFS was added, but it is tied to the main "name" variable for the module, and does not contain the logic to allow for uniques names when passing them in differently. 

## Motivation and Context
Declaring a unique name in the EFS array did not allow for setting unique names. Default/unique name for the module was applied from the Atlantis module.