### PR TITLE
chore: Working examples for repo_allowlist (#394)

### DIFF
--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -55,6 +55,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="input_atlantis_github_user"></a> [atlantis\_github\_user](#input\_atlantis\_github\_user) | GitHub user or organization name | `string` | n/a | yes |
 | <a name="input_atlantis_repo_allowlist"></a> [atlantis\_repo\_allowlist](#input\_atlantis\_repo\_allowlist) | List of GitHub repositories that Atlantis will be allowed to access | `list(string)` | n/a | yes |
 | <a name="input_domain"></a> [domain](#input\_domain) | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance | `string` | n/a | yes |
+| <a name="input_git_host_domain"></a> [git\_host\_domain](#input\_git\_host\_domain) | Example: github.com | `string` | n/a | yes |
 | <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Github owner to use when creating webhook | `string` | n/a | yes |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token to use when creating webhook | `string` | n/a | yes |
 

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -45,7 +45,7 @@ module "atlantis" {
       },
       {
         name  = "ATLANTIS_REPO_ALLOWLIST"
-        value = join(",", var.atlantis_repo_allowlist)
+        value = join(",", formatlist("${var.git_host_domain}/${var.github_owner}/%s", var.atlantis_repo_allowlist))
       },
       {
         name  = "ATLANTIS_ENABLE_DIFF_MARKDOWN_FORMAT"

--- a/examples/github-complete/terraform.tfvars.sample
+++ b/examples/github-complete/terraform.tfvars.sample
@@ -2,6 +2,6 @@ github_token = "ghp_aldkfjadkfjaldfjk"
 github_owner = "me"
 
 domain = "mydomain.com"
-
+git_host_domain = "github.com"
 atlantis_github_user = "JohnDoe"
 atlantis_repo_allowlist = ["my-repo"]

--- a/examples/github-complete/variables.tf
+++ b/examples/github-complete/variables.tf
@@ -22,3 +22,8 @@ variable "atlantis_repo_allowlist" {
   description = "List of GitHub repositories that Atlantis will be allowed to access"
   type        = list(string)
 }
+
+variable "git_host_domain" {
+  description = "Example: github.com"
+  type        = string
+}

--- a/examples/github-separate/README.md
+++ b/examples/github-separate/README.md
@@ -56,6 +56,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|-------------|------|---------|:--------:|
 | <a name="input_atlantis_github_user"></a> [atlantis\_github\_user](#input\_atlantis\_github\_user) | GitHub user or organization name | `string` | n/a | yes |
 | <a name="input_atlantis_repo_allowlist"></a> [atlantis\_repo\_allowlist](#input\_atlantis\_repo\_allowlist) | List of GitHub repositories that Atlantis will be allowed to access | `list(string)` | n/a | yes |
+| <a name="input_git_host_domain"></a> [git\_host\_domain](#input\_git\_host\_domain) | Example: github.com | `string` | n/a | yes |
 | <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Github owner to use when creating webhook | `string` | n/a | yes |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token to use when creating webhook | `string` | n/a | yes |
 

--- a/examples/github-separate/main.tf
+++ b/examples/github-separate/main.tf
@@ -50,7 +50,7 @@ module "atlantis" {
       },
       {
         name  = "ATLANTIS_REPO_ALLOWLIST"
-        value = join(",", var.atlantis_repo_allowlist)
+        value = join(",", formatlist("${var.git_host_domain}/${var.github_owner}/%s", var.atlantis_repo_allowlist))
       },
       {
         name  = "ATLANTIS_ENABLE_DIFF_MARKDOWN_FORMAT"

--- a/examples/github-separate/variables.tf
+++ b/examples/github-separate/variables.tf
@@ -17,3 +17,8 @@ variable "atlantis_repo_allowlist" {
   description = "List of GitHub repositories that Atlantis will be allowed to access"
   type        = list(string)
 }
+
+variable "git_host_domain" {
+  description = "Example: github.com"
+  type        = string
+}


### PR DESCRIPTION
## Description
This adds a new input var for the github host, then combines that domain + owner + repo list to produce full url. 

More details: https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/394, https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/384

## Motivation and Context
Following the README will default to non-working `atlantis_repo_allowlist` for webhooks, or for atlantis module (depends on whether you try `terraform-aws-modules/terraform-aws-atlantis` or `terraform-aws-atlantis`. (User will get `Error: This repo is not allowlisted for Atlantis.`)


## Breaking Changes
No. Just documentation example update, but important for someone following these examples.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
