### PR TITLE
docs: Update examples to show inputs required for Atlantis vs the webhook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.83.6
+    rev: v1.86.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -26,3 +26,5 @@ repos:
     rev: v4.5.0
     hooks:
       - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -57,6 +57,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="input_domain"></a> [domain](#input\_domain) | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance | `string` | n/a | yes |
 | <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Github owner to use when creating webhook | `string` | n/a | yes |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token to use when creating webhook | `string` | n/a | yes |
+| <a name="input_repositories"></a> [repositories](#input\_repositories) | List of GitHub repositories to create webhooks for. This is just the name of the repository, excluding the user or organization | `list(string)` | n/a | yes |
 
 ## Outputs
 

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -108,7 +108,7 @@ module "atlantis" {
 module "github_repository_webhooks" {
   source = "../../modules/github-repository-webhook"
 
-  repositories = var.atlantis_repo_allowlist
+  repositories = var.repositories
 
   webhook_url    = "${module.atlantis.url}/events"
   webhook_secret = random_password.webhook_secret.result

--- a/examples/github-complete/terraform.tfvars.sample
+++ b/examples/github-complete/terraform.tfvars.sample
@@ -4,4 +4,6 @@ github_owner = "me"
 domain = "mydomain.com"
 
 atlantis_github_user = "JohnDoe"
-atlantis_repo_allowlist = ["my-repo"]
+# Format is {hostname}/{owner}/{repo} https://www.runatlantis.io/docs/server-configuration.html#repo-allowlist
+atlantis_repo_allowlist = ["github.com/johndoe/*"]
+repositories = ["myrepo"]

--- a/examples/github-complete/variables.tf
+++ b/examples/github-complete/variables.tf
@@ -22,3 +22,8 @@ variable "atlantis_repo_allowlist" {
   description = "List of GitHub repositories that Atlantis will be allowed to access"
   type        = list(string)
 }
+
+variable "repositories" {
+  description = "List of GitHub repositories to create webhooks for. This is just the name of the repository, excluding the user or organization"
+  type        = list(string)
+}

--- a/examples/github-separate/README.md
+++ b/examples/github-separate/README.md
@@ -58,6 +58,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="input_atlantis_repo_allowlist"></a> [atlantis\_repo\_allowlist](#input\_atlantis\_repo\_allowlist) | List of GitHub repositories that Atlantis will be allowed to access | `list(string)` | n/a | yes |
 | <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Github owner to use when creating webhook | `string` | n/a | yes |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token to use when creating webhook | `string` | n/a | yes |
+| <a name="input_repositories"></a> [repositories](#input\_repositories) | List of GitHub repositories to create webhooks for. This is just the name of the repository, excluding the user or organization | `list(string)` | n/a | yes |
 
 ## Outputs
 

--- a/examples/github-separate/main.tf
+++ b/examples/github-separate/main.tf
@@ -87,7 +87,7 @@ module "atlantis" {
 module "github_repository_webhooks" {
   source = "../../modules/github-repository-webhook"
 
-  repositories = var.atlantis_repo_allowlist
+  repositories = var.repositories
 
   webhook_url    = "http://${module.alb.dns_name}/events"
   webhook_secret = random_password.webhook_secret.result

--- a/examples/github-separate/terraform.tfvars.sample
+++ b/examples/github-separate/terraform.tfvars.sample
@@ -2,4 +2,6 @@ github_token = "ghp_aldkfjadkfjaldfjk"
 github_owner = "me"
 
 atlantis_github_user = "JohnDoe"
-atlantis_repo_allowlist = ["my-repo"]
+# Format is {hostname}/{owner}/{repo} https://www.runatlantis.io/docs/server-configuration.html#repo-allowlist
+atlantis_repo_allowlist = ["github.com/johndoe/*"]
+repositories = ["myrepo"]

--- a/examples/github-separate/variables.tf
+++ b/examples/github-separate/variables.tf
@@ -17,3 +17,8 @@ variable "atlantis_repo_allowlist" {
   description = "List of GitHub repositories that Atlantis will be allowed to access"
   type        = list(string)
 }
+
+variable "repositories" {
+  description = "List of GitHub repositories to create webhooks for. This is just the name of the repository, excluding the user or organization"
+  type        = list(string)
+}


### PR DESCRIPTION
## Description
- Update examples to show inputs required for Atlantis vs the webhook

## Motivation and Context
- Resolves #394
- Closes #395

## Breaking Changes
- No, just updates the examples

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
