### PR TITLE
fix: Change default deployment percentages when using EFS to allow updates to succeed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.86.0
+    rev: v1.88.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/main.tf
+++ b/main.tf
@@ -188,6 +188,10 @@ locals {
     sourceVolume  = "efs"
     readOnly      = false
   }] : try(var.atlantis.mount_points, [])
+
+  # Ref https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/383
+  deployment_maximum_percent         = var.enable_efs ? 100 : 200
+  deployment_minimum_healthy_percent = var.enable_efs ? 0 : 66
 }
 
 module "ecs_cluster" {
@@ -229,8 +233,8 @@ module "ecs_service" {
   capacity_provider_strategy         = try(var.service.capacity_provider_strategy, {})
   cluster_arn                        = var.create_cluster && var.create ? module.ecs_cluster.arn : var.cluster_arn
   deployment_controller              = try(var.service.deployment_controller, {})
-  deployment_maximum_percent         = try(var.service.deployment_maximum_percent, 200)
-  deployment_minimum_healthy_percent = try(var.service.deployment_minimum_healthy_percent, 66)
+  deployment_maximum_percent         = try(var.service.deployment_maximum_percent, local.deployment_maximum_percent)
+  deployment_minimum_healthy_percent = try(var.service.deployment_minimum_healthy_percent, local.deployment_minimum_healthy_percent)
   desired_count                      = try(var.service.desired_count, 1)
   enable_ecs_managed_tags            = try(var.service.enable_ecs_managed_tags, true)
   enable_execute_command             = try(var.service.enable_execute_command, false)


### PR DESCRIPTION
## Description
- Change default deployment percentages when using EFA to allow updates to succeed

## Motivation and Context
- Resolves #383

## Breaking Changes
- No; this changes the default value (when one is not provided by users) when `enable_efa = true` which according to #383, does not work as intended today

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
