### PR TITLE
feat: make load balancer optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,10 +235,10 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alb"></a> [alb](#input\_alb) | Map of values passed to ALB module definition. See the [ALB module](https://github.com/terraform-aws-modules/terraform-aws-alb) for full list of arguments supported | `any` | `{}` | no |
-| <a name="input_alb_https_default_action"></a> [alb\_https\_default\_action](#input\_alb\_https\_default\_action) | Default action for the ALB https listener | `any` | <pre>{<br/>  "forward": {<br/>    "target_group_key": "atlantis"<br/>  }<br/>}</pre> | no |
-| <a name="input_alb_security_group_id"></a> [alb\_security\_group\_id](#input\_alb\_security\_group\_id) | ID of an existing security group that will be used by ALB. Required if `create_alb` is `false` | `string` | `""` | no |
+| <a name="input_alb_https_default_action"></a> [alb\_https\_default\_action](#input\_alb\_https\_default\_action) | Default action for the ALB https listener | `any` | <pre>{<br>  "forward": {<br>    "target_group_key": "atlantis"<br>  }<br>}</pre> | no |
+| <a name="input_alb_security_group_id"></a> [alb\_security\_group\_id](#input\_alb\_security\_group\_id) | ID of an existing security group that will be used by ALB. | `string` | `""` | no |
 | <a name="input_alb_subnets"></a> [alb\_subnets](#input\_alb\_subnets) | List of subnets to place ALB in. Required if `create_alb` is `true` | `list(string)` | `[]` | no |
-| <a name="input_alb_target_group_arn"></a> [alb\_target\_group\_arn](#input\_alb\_target\_group\_arn) | ARN of an existing ALB target group that will be used to route traffic to the Atlantis service. Required if `create_alb` is `false` | `string` | `""` | no |
+| <a name="input_alb_target_group_arn"></a> [alb\_target\_group\_arn](#input\_alb\_target\_group\_arn) | ARN of an existing ALB target group that will be used to route traffic to the Atlantis service. | `string` | `""` | no |
 | <a name="input_atlantis"></a> [atlantis](#input\_atlantis) | Map of values passed to Atlantis container definition. See the [ECS container definition module](https://github.com/terraform-aws-modules/terraform-aws-ecs/tree/master/modules/container-definition) for full list of arguments supported | `any` | `{}` | no |
 | <a name="input_atlantis_gid"></a> [atlantis\_gid](#input\_atlantis\_gid) | GID of the atlantis user | `number` | `1000` | no |
 | <a name="input_atlantis_uid"></a> [atlantis\_uid](#input\_atlantis\_uid) | UID of the atlantis user | `number` | `100` | no |

--- a/main.tf
+++ b/main.tf
@@ -447,7 +447,7 @@ module "ecs_service" {
         protocol                 = "tcp"
         source_security_group_id = var.create_alb ? module.alb.security_group_id : var.alb_security_group_id
       }
-    }: {},
+    } : {},
     lookup(var.service, "security_group_rules", {
       egress = {
         type        = "egress"

--- a/variables.tf
+++ b/variables.tf
@@ -51,13 +51,13 @@ variable "create_alb" {
 }
 
 variable "alb_target_group_arn" {
-  description = "ARN of an existing ALB target group that will be used to route traffic to the Atlantis service. Required if `create_alb` is `false`"
+  description = "ARN of an existing ALB target group that will be used to route traffic to the Atlantis service."
   type        = string
   default     = ""
 }
 
 variable "alb_security_group_id" {
-  description = "ID of an existing security group that will be used by ALB. Required if `create_alb` is `false`"
+  description = "ID of an existing security group that will be used by ALB."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This makes the usage of a load balancer completely optional since it might not be needed to access atlantis. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently we are forcing the usage of a load balancer associated to the ecs service. That might not be needed since the access could be provided with something like cloudflare tunnels or AWS SSM sessions to make atlantis accessible from private networks without the need of a load balancer.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
