### PR TITLE
feat: Enable to set additional mount points

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -186,11 +186,11 @@ module "acm" {
 
 locals {
   mount_path = "/home/atlantis"
-  mount_points = var.enable_efs ? [{
+  mount_points = var.enable_efs ? concat(try(var.atlantis.mount_points, []), [{
     containerPath = local.mount_path
     sourceVolume  = "efs"
     readOnly      = false
-  }] : try(var.atlantis.mount_points, [])
+  }]) : try(var.atlantis.mount_points, [])
 
   # Ref https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/383
   deployment_maximum_percent         = var.enable_efs ? 100 : 200


### PR DESCRIPTION
## Description

This will allow to add mount points in the container alongside EFS.


## Motivation and Context

When `enable_efs` is set to `true` it is not possible to set additional mount points for the container.
In case when you need to set `readonlyRootFilesystem` this could be necessary for accesing the container via session manager.

Links:
- https://toris.io/2021/06/using-ecs-exec-with-readonlyrootfilesystem-enabled-containers/
- https://github.com/aws/containers-roadmap/issues/1359

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
