### PR TITLE
fix: Allow additional EFS volumes without enable_efs=true

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -386,7 +386,7 @@ module "ecs_service" {
       }
     },
     lookup(var.service, "volume", {})
-  ) : k => v if var.enable_efs }
+  ) : k => v if k != "efs" || var.enable_efs }
   task_tags = try(var.service.task_tags, {})
 
   # Task execution IAM role


### PR DESCRIPTION
This is required to allow mounting any arbitrary paths for atlantis features like team_authz, or webhooks, without needing to set `enable_efs=true`. These are settings that are global so they should not be part of any particular github repo that uses atlantis.

## Description
Only required modifying on line in main.tf to allow additional volumes if the volume name is not "efs"

## Motivation and Context
My use-case is that I need to add a team_authz script to control permissions for who can run TF apply on prod deployments. The script cannot go in a specific repo, and I didn't want to build it into a custom atlantis image. This fixes issue #408 .

## Breaking Changes
None.

## How Has This Been Tested?
I've tested it in our company environment and it works great.