### PR TITLE
fix: Allow empty string as Route53 record name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,12 +15,12 @@ locals {
 locals {
   route53_records = {
     A = {
-      name    = try(coalesce(var.route53_record_name, var.name), "")
+      name    = try(var.route53_record_name != null ? var.route53_record_name : var.name, "")
       type    = "A"
       zone_id = var.route53_zone_id
     }
     AAAA = {
-      name    = try(coalesce(var.route53_record_name, var.name), "")
+      name    = try(var.route53_record_name != null ? var.route53_record_name : var.name, "")
       type    = "AAAA"
       zone_id = var.route53_zone_id
     }


### PR DESCRIPTION
## Description
Changes the way the Route53 record names are calculated, so they now align with the documentation. See #415 for further details on the background for this change.

## Motivation and Context

If you want Atlantis to be hosted under the same FQDN as the Route53 zone under which it is registered, the Route53 record must be created with empty string (`""`) as its name. Unfortunately the current way the code works doesn't allow this (see #415).

This PR rewrites the logic so the name now falls back to `var.name` iff `var.route53_record_name == null` (which is the default). If the caller explicitly sets `route53_record_name = ""`, then that will be used instead as the Route53 record name.

Note that this aligns with the way the documentation for the `route53_record_name` input is written. The previous behavior was a bug, that made the implemented behavior not act as the documentation describes. This PR simply fixes the bug.

Fixes #415 

## Breaking Changes
Technically this is a breaking change; it changes what resources a given input spins up. This change is made to align it with the documentation, though, so there is no breaking change for _documented behavior_.

Whether you consider that a breaking change is up to the project maintainers.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

This has been tested locally to give the correct result. Since this is a niché use case (creating the Route53 record under the same name as the zone), I don't feel it relevant to add it to the `examples/*` documentation. That would likely just muddle the communication that the examples provide.

I have only copied out the `locals` block into a local TF project, and verified that the result is as intended. That is, I _haven't_ spun up the module, made the changes, and verified that there are no infrastructure changes.