### PR TITLE
feat: Add support for deployment_circuit_breaker configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,26 @@ module "atlantis" {
 }
 ```
 
+### Enable Deployment Circuit Breaker
+
+You can enable the ECS deployment circuit breaker to automatically roll back failed deployments:
+
+```hcl
+module "atlantis" {
+  source  = "terraform-aws-modules/atlantis/aws"
+
+  # ...
+
+  service = {
+    # Enable circuit breaker for automatic rollback on failed deployments
+    deployment_circuit_breaker = {
+      enable   = true
+      rollback = true
+    }
+  }
+}
+```
+
 ## Examples
 
 - [Complete Atlantis with GitHub webhook](https://github.com/terraform-aws-modules/terraform-aws-atlantis/tree/master/examples/github-complete)

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -70,6 +70,12 @@ module "atlantis" {
     tasks_iam_role_policies = {
       AdministratorAccess = "arn:aws:iam::aws:policy/AdministratorAccess"
     }
+
+    # Enable circuit breaker for automatic rollback on failed deployments
+    deployment_circuit_breaker = {
+      enable   = true
+      rollback = true
+    }
   }
 
   # ALB

--- a/main.tf
+++ b/main.tf
@@ -235,6 +235,7 @@ module "ecs_service" {
   alarms                             = try(var.service.alarms, {})
   capacity_provider_strategy         = try(var.service.capacity_provider_strategy, {})
   cluster_arn                        = var.create_cluster && var.create ? module.ecs_cluster.arn : var.cluster_arn
+  deployment_circuit_breaker         = try(var.service.deployment_circuit_breaker, {})
   deployment_controller              = try(var.service.deployment_controller, {})
   deployment_maximum_percent         = try(var.service.deployment_maximum_percent, local.deployment_maximum_percent)
   deployment_minimum_healthy_percent = try(var.service.deployment_minimum_healthy_percent, local.deployment_minimum_healthy_percent)


### PR DESCRIPTION
## Description
This change adds support for the ECS deployment circuit breaker feature, which allows for automatic rollback of failed deployments.

The deployment_circuit_breaker configuration is now passed through from the service variable to the underlying ECS service module, enabling users to configure automatic rollback behavior for their Atlantis deployments.

Example usage:
```hcl
service = {
  deployment_circuit_breaker = {
    enable   = true
    rollback = true
  }
}
```

Tested locally by referencing the module and confirming the circuit breaker configuration is properly applied to the ECS service.

## Motivation and Context
We need to be able to set this config on ECS Tasks.

## Breaking Changes
No breaking changes as it uses a default blank object if not passed.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
