### PR TITLE
fix: Update lookup logic for Atlantis URL due to variable optional attributes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,12 @@
 locals {
   # Atlantis
-  atlantis_url = "https://${try(coalesce(
-    try(var.atlantis.fqdn, module.alb.route53_records["A"].fqdn, null),
-    module.alb.dns_name,
-  ), "")}"
+  atlantis_url = "https://${try(
+    coalesce(
+      var.atlantis.fqdn,
+      try(module.alb.route53_records["A"].fqdn, null),
+      module.alb.dns_name,
+    ),
+  "")}"
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
- Update lookup logic for Atlantis URL due to variable optional attributes

## Motivation and Context
- The current logic will resolve `try(var.atlantis.fqdn, module.alb.route53_records["A"].fqdn, null),` as `null` when not providing a `fqdn` because of the variable optional attributes (does not fall back to the next value on error, no error provided - just `null`). This coupled with the overall `coalesce()` means that the ALB DNS name is commonly exported instead of the URL using the Route53 record created by the module

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
