### PR TITLE
feat: Add support for service registries

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -399,6 +399,9 @@ module "ecs_service" {
   )
   security_group_tags = var.service.security_group_tags
 
+  # Service Discovery Registries
+  service_registries = var.service.service_registries
+
   tags = var.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -597,6 +597,14 @@ variable "service" {
       }
     )
     security_group_tags = optional(map(string), {})
+
+    # Service Discovery Registries
+    service_registries = optional(object({
+      container_name = optional(string)
+      container_port = optional(number)
+      port           = optional(number)
+      registry_arn   = string
+    }))
   })
   default = {}
 }


### PR DESCRIPTION
## Description
Adding ability to configure service registries in the Atlantis module.

## Motivation and Context
https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/438

Main motivation is the issue above that was raised by my colleague.

TLDR; We want to reach out to Atlantis(and its API endpoints) from within the VPC and for the requests to stay internal to the VPC. We do see that the Atlantis module uses the upstream ECS module which has the `service_registries` variable available [here](https://github.com/terraform-aws-modules/terraform-aws-ecs/blob/master/modules/service/variables.tf#L317-L326). We just want to expose this variable from the Atlantis module to allow us to configure service registries for our Atlantis instances.

First time contributing to this project so if I missed anything, let me know. Hoping for your consideration on this PR. Thanks!

## Breaking Changes
none

## How Has This Been Tested?
Tested locally by deploying my forked repo's Atlantis module version. No issues encountered as expected.