### PR TITLE
feat(atlantis): Add cloudwatch_log_group_name support for atlantis co…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -307,6 +307,7 @@ module "ecs_service" {
         service                                = try(coalesce(var.service.name, var.name))
         enable_cloudwatch_logging              = var.atlantis.enable_cloudwatch_logging
         create_cloudwatch_log_group            = var.atlantis.create_cloudwatch_log_group
+        cloudwatch_log_group_name              = var.atlantis.cloudwatch_log_group_name
         cloudwatch_log_group_use_name_prefix   = var.atlantis.cloudwatch_log_group_use_name_prefix
         cloudwatch_log_group_retention_in_days = var.atlantis.cloudwatch_log_group_retention_in_days
         cloudwatch_log_group_class             = var.atlantis.cloudwatch_log_group_class

--- a/variables.tf
+++ b/variables.tf
@@ -151,6 +151,7 @@ variable "atlantis" {
     # CloudWatch Log Group
     enable_cloudwatch_logging              = optional(bool, true)
     create_cloudwatch_log_group            = optional(bool, true)
+    cloudwatch_log_group_name              = optional(string)
     cloudwatch_log_group_use_name_prefix   = optional(bool, true)
     cloudwatch_log_group_retention_in_days = optional(number, 14)
     cloudwatch_log_group_class             = optional(string)


### PR DESCRIPTION
## Description

Add `cloudwatch_log_group_name` to the atlantis container definition so users can customize the CloudWatch log group name for the atlantis container.

## Motivation and Context

All other `cloudwatch_log_group_*` attributes (`use_name_prefix`, `retention_in_days`, `class`, `kms_key_id`) were already being passed through correctly. This PR adds the missing one.

## Breaking Changes

None. `cloudwatch_log_group_name` defaults to `null`, preserving the existing default naming behaviour.

